### PR TITLE
Use Promise.resolve in the events no queries are found

### DIFF
--- a/src/server/index.js
+++ b/src/server/index.js
@@ -112,7 +112,7 @@ export function getLoadableState(
   const queries = getQueriesFromTree({ rootElement, rootContext }, fetchRoot)
 
   // no queries found, nothing to do
-  if (!queries.length) return new DeferredState([])
+  if (!queries.length) return Promise.resolve(new DeferredState([]))
 
   const errors = []
   let componentIds = []


### PR DESCRIPTION
When on the server doing:

`
getLoadableState(app).then(loadableState => { ... })
`
if no queries are found, throws an error because DeferredState is returned, not a Promise.