### PR TITLE
Add support to HMR

### DIFF
--- a/src/componentTracker.js
+++ b/src/componentTracker.js
@@ -8,5 +8,6 @@ export const track = component => {
   return id
 }
 
+export const loadableHMR = () => { currentId = 0 }
 export const get = id => components[id]
 export const getAll = () => ({ ...components })

--- a/src/componentTracker.js
+++ b/src/componentTracker.js
@@ -9,8 +9,8 @@ export const track = component => {
 }
 
 export const loadableHMR = () => {
-  currentId = 0;
-  components = {};
+  currentId = 0
+  components = {}
 }
 export const get = id => components[id]
 export const getAll = () => ({ ...components })

--- a/src/componentTracker.js
+++ b/src/componentTracker.js
@@ -1,5 +1,5 @@
 let currentId = 0
-const components = {}
+let components = {}
 
 export const track = component => {
   const id = currentId
@@ -8,6 +8,9 @@ export const track = component => {
   return id
 }
 
-export const loadableHMR = () => { currentId = 0 }
+export const loadableHMR = () => {
+  currentId = 0;
+  components = {};
+}
 export const get = id => components[id]
 export const getAll = () => ({ ...components })

--- a/src/componentTracker.test.js
+++ b/src/componentTracker.test.js
@@ -16,4 +16,14 @@ describe('componentTracker', () => {
       [id2]: Component2,
     })
   })
+
+  it('should be possible to reset tracking', () => {
+    componentTracker.track(() => null)
+    componentTracker.track(() => null)
+
+    componentTracker.loadableHMR()
+
+    expect(componentTracker.getAll()).toEqual({})
+    expect(componentTracker.track(() => null)).toEqual(0)
+  })
 })


### PR DESCRIPTION
This is a fix for #10 

The reason why that error happens in the first place is because eveyrtime there's an HMR, the tree is recalculated, and since `currentId` and the `components`, don't get a reset on the server side, it keeps adding to those variables.

When a page is refreshed on the fronted, the tracker starts empty, so `currentId = 0` and `components= {}` creating a mismatch on the ids of the components from the backend to the frontend.

small example, if we have this routes.js:

```
// Routes.js
import loadable from 'loadable-components'

export const Home = loadable(() => import('./Home'))
export const About = loadable(() => import('./About'))
export const Contact = loadable(() => import('./Contact'))
```

**componentTracker.js** will be:
```
currentId = 3
components = {
  0: loadableFunc, // Home
  1: loadableFunc, // About
  2: loadableFunc, // Contact
}
```

if there's a HMR event on the server and frontend it will be: 

```
currentId = 6
components = {
  0: loadableFunc, // Home
  1: loadableFunc, // About
  2: loadableFunc, // Contact
  3: loadableFunc, // Home
  4: loadableFunc, // About
  5: loadableFunc, // Contact 
}
```

As long as we don't refresh the front end they will both be in sync, as soon we do a refresh, for example on the route  `/home`

server's  *componentTracker.js*:

```
currentId = 6
components = {
  0: loadableFunc, // Home
  1: loadableFunc, // About
  2: loadableFunc, // Contact
  3: loadableFunc, // Home
  4: loadableFunc, // About
  5: loadableFunc, // Contact 
}
```

it will return the id 3, because it's our current id for the **HomeComponent**:

But on the frontend our **componentTracker** will be:
```
components = {
  0: loadableFunc, // Home
  1: loadableFunc, // About
  2: loadableFunc, // Contact
}
```

And that's why we get an exception.

Now the function itself isn't the solution but it's part of it, the next step is simple adding this to our HMR part on the server and on the client:

**myServer.js**
```
import { loadableHMR } from 'loadable-components/componentTracker';
import app from './server';

if (module.hot) {
  module.hot.accept('./server', () => {
    console.log('🔁  HMR Reloading `./server`...');
    loadableHMR();
  });

  console.info('✅  Server-side HMR Enabled!');
}
```

**myClient.js**
```
import { loadableHMR } from 'loadable-components/componentTracker';

if (module.hot) {
  module.hot.accept();
  // hot.accept doesn't accept a callback, when the first arg is undefined  so we use the dispose
  module.hot.dispose(() => {
    loadableHMR();
  });
}
```

Basically what's happening in there, is whenever there's a HMR, just reset our componentTracker, so everyone will be in sync again. It may also prevent memory leaks in the future if we had zillions of HMR events along with zillions of loadable components

PS:
Do you want me to add a simple test for the function as this might decrease code coverage?

PPS:
Added tests anyway
