### PR TITLE
Change name passed in to renderToString

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,7 +274,7 @@ const app = (
 
 // Extract loadable state from application tree
 getLoadableState(app).then(loadableState => {
-  const html = renderToString(<YourApp />)
+  const html = renderToString(app)
   // Insert style tag into page
   const page = `
     <!doctype html>


### PR DESCRIPTION
Hey guys! First of all, great library! It's the best React code splitting library I've used. I may have found something in the docs that needs a correction or clarification. I didn't see `<YourApp />` declared anywhere and using `app` works for me. If I've got that correct, here's a PR to help with make the change.

Thanks again for the great work!