### PR TITLE
Reload component every time when update async component code in  development mode

### DIFF
--- a/src/loadable.js
+++ b/src/loadable.js
@@ -90,7 +90,10 @@ function loadable(
       return <LoadingComponent {...this.props} />
     }
   }
-
+  // development mode load every time
+  if(process.env.NODE_ENV === 'development'){
+    LoadableComponent.load()
+  }
   LoadableComponent[LOADABLE] = () => LoadableComponent
 
   if (modules) {


### PR DESCRIPTION
When using code splitting, additional `hot(module)` are needed because the updated components are not reloaded. Every time we need to add `hot(module)` to track the changes of asynchronous components. This makes me feel very troublesome, so every time I call the `loadable` method in `development mode`, I'm going to reload the asynchronous components once by default.  
This eliminates the need for additional `hot(module)` inside each asynchronous component.

Only one `hot(module)(App)`!