### PR TITLE
Fix/circular

### DIFF
--- a/src/server/index.js
+++ b/src/server/index.js
@@ -139,16 +139,15 @@ export function getLoadableState(
 
   return Promise.all(mappedQueries).then(() => {
     if (errors.length > 0) {
-      const error =
-        errors.length === 1
-          ? errors[0]
-          : new Error(
-              `${
-                errors.length
-              } errors were thrown when importing your modules.`,
-            )
-      error.queryErrors = errors
-      throw error
+      if (errors.length === 1) {
+        throw errors[0];
+      } else {
+        const err = new Error(
+          `${errors.length} errors were thrown when importing your modules.`
+        );
+        err.errors = errors;
+        throw err;
+      }
     }
 
     return new DeferredState(tree)

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -145,7 +145,7 @@ export function getLoadableState(
         const err = new Error(
           `${errors.length} errors were thrown when importing your modules.`
         );
-        err.errors = errors;
+        err.queryErrors = errors
         throw err;
       }
     }


### PR DESCRIPTION
In some cases (when we had one error) circular structure was created in error object.

Now, if we will have one error we throw it without linking it to itself in queryErrors.