### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -488,7 +488,7 @@ class ComponentWithTranslations extends React.Component {
 
 The main difference between these two libraries is the server-side rendering approach:
 
-* `react-loadable` requires a babel plugin. I think it's too complicated and we should not rely on it.
+* `react-loadable` requires a webpack plugin and a babel plugin. I think it's too complicated and we should not rely on it.
 * `react-async-component` has a better approach, analyzing tree + context, it also rely on another library. I like the idea but not the API.
 
 `loadable-components` has a simpler approach, it relies on [dynamic-import-specification](https://github.com/tc39/proposal-dynamic-import) and assumes that [it is working for node and Webpack](https://babeljs.io/docs/plugins/syntax-dynamic-import/). Then it analyzes the tree server-side and waiting for every modules to be loaded. Client-side it loads modules before rendering the application. The API is as simple as possible, no context, no magic variable.


### PR DESCRIPTION
On the README, on why you don't like `react-loadable` I think you meant a 'webpack plugin', because `loadable-components` relies on a 'babel plugin' too.