### PR TITLE
Fix typo and improve error message

### DIFF
--- a/src/server/index.js
+++ b/src/server/index.js
@@ -145,7 +145,7 @@ function getQueriesFromTree(
       const query = loadable.load().then(() => {
         if (!loadable.componentId) {
           throw new Error(
-            'loadable-components: modules entry is missing, your are probably missing `loadable-components/babel`',
+            'loadable-components: modules entry is missing, you are probably missing `loadable-components/babel` in your Babel config.',
           )
         }
         return loadable.componentId


### PR DESCRIPTION
`your are` -> `you are`
Also specify that the configuration is missing in the Babel config.