### PR TITLE
chore: clone last 5 commits

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,3 +19,6 @@ cache:
   directories:
     - ".eslintcache"
     - "node_modules"
+
+git:
+  depth: 5


### PR DESCRIPTION
By default Travis clones the last 50 commits. 5 are sufficient and faster.

See https://docs.travis-ci.com/user/customizing-the-build#Git-Clone-Depth