### PR TITLE
On client-side init error return rejected promise rather than throw

### DIFF
--- a/src/loadComponents.js
+++ b/src/loadComponents.js
@@ -10,29 +10,26 @@ function loadState(rootState) {
       const component = componentTracker.get(state.id)
 
       if (!component) {
-        console.warn(
+        console.warn( // eslint-disable-line
           'loadable-component client modules:',
           componentTracker.getAll(),
         )
-        console.warn(
+        console.warn( // eslint-disable-line
           'loadable-component server modules:',
           window[LOADABLE_STATE],
         )
-        throw new Error(
-          `loadable-components: module "${
-            state.id
-          }" is not found, client and server modules are not sync. You are probably not using the same resolver on server and client.`,
-        )
+
+        return Promise.reject(new Error(`loadable-components: module "${
+          state.id
+        }" is not found, client and server modules are not sync. You are probably not using the same resolver on server and client.`))
       }
 
       const getLoadable = component[LOADABLE]
 
       if (typeof getLoadable !== 'function') {
-        throw new Error(
-          `loadable-components: module "${
-            state.id
-          }" is not a loadable component, please verify your SSR setup`,
-        )
+        return Promise.reject(new Error(`loadable-components: module "${
+          state.id
+        }" is not a loadable component, please verify your SSR setup`))
       }
 
       return getLoadable()
@@ -44,18 +41,15 @@ function loadState(rootState) {
 
 function loadComponents() {
   if (typeof window === 'undefined') {
-    throw new Error(
-      'loadable-components: `loadComponents` must be called client-side: `window` is undefined',
-    )
+    return Promise.reject(new Error('loadable-components: `loadComponents` must ' +
+      'be called client-side: `window` is undefined'))
   }
 
   const state = window[LOADABLE_STATE]
   if (!state) {
-    throw new Error(
-      'loadable-components state not found. ' +
-        'You have a problem server-side. ' +
-        'Please verify that you have called `loadableState.getScriptTag()` server-side.',
-    )
+    return Promise.reject(new Error('loadable-components state not found. ' +
+      'You have a problem server-side. ' +
+      'Please verify that you have called `loadableState.getScriptTag()` server-side.'))
   }
 
   return loadState(state)


### PR DESCRIPTION
This swaps out an error with a rejected promise so that client UI doesn't break. Noticed when used in conjunction with [`@artsy/express-reloadable`](https://github.com/artsy/express-reloadable) that when reloads occur and module ids increment an error occurs when really there's no problem. 

(Really excellent lib -- was totally painless to setup compared to all of the others 👍) 

