### PR TITLE
Don't reject when missing __LOADABLE_STATE__, just log

### DIFF
--- a/src/loadComponents.js
+++ b/src/loadComponents.js
@@ -47,9 +47,11 @@ function loadComponents() {
 
   const state = window[LOADABLE_STATE]
   if (!state) {
-    return Promise.reject(new Error('loadable-components state not found. ' +
+    console.error('loadable-components state not found. ' + // eslint-disable-line
       'You have a problem server-side. ' +
-      'Please verify that you have called `loadableState.getScriptTag()` server-side.'))
+      'Please verify that you have called `loadableState.getScriptTag()` server-side.')
+
+    return Promise.resolve(null)
   }
 
   return loadState(state)

--- a/src/loadComponents.test.js
+++ b/src/loadComponents.test.js
@@ -25,15 +25,13 @@ describe('loadComponents', () => {
     }
   })
 
-  it('rejects when no LOADABLE_STATE', async () => {
+  it('logs an error warning when no LOADABLE_STATE', async () => {
     delete window[LOADABLE_STATE]
-
+    global.console.error = jest.fn()
     expect.assertions(1)
-    try {
-      await loadComponents()
-    } catch (error) {
-      expect(error.message).toMatch(/loadable-components state not found/)
-    }
+    await loadComponents()
+    const errorWarning = global.console.error.mock.calls[0][0]
+    expect(errorWarning).toMatch(/loadable-components state not found/)
   })
 
   it('rejects when no component is found in componentTracker', async () => {


### PR DESCRIPTION
This is a follow up to https://github.com/smooth-code/loadable-components/pull/87.

I'm building out an SSR framework and noticed that when I disable SSR and only mount client-side, the rejection with an error will stop execution. 

Rather than having to try / catch this individual branch or check for the existence of `window.__LOADABLE_STATE__` and binding my code to `loadable-components` internals, logging and treating missing state like a `noop` is more appropriate.

(While `reject(new Error())` makes sense in most cases within `loadComponents.js`, missing state shouldn't break the UI since if state is missing loadable components will boot like normal, but without hydration data. This is similar to when `ReactDOM.hydrate` receives html mismatch, but doesn't error out and only logs as an error.)

