### PR TITLE
Fix server-side type definitions

### DIFF
--- a/server.d.ts
+++ b/server.d.ts
@@ -1,0 +1,16 @@
+// TypeScript Version: 2.4
+
+import * as React from 'react';
+
+export function getLoadableState(
+  rootElement: React.ReactElement<{}>,
+  rootContext?: any,
+  fetchRoot?: boolean,
+  tree?: any,
+): Promise<DeferredState>;
+
+export interface DeferredState {
+  getScriptContent(): string;
+  getScriptTag(): string;
+  getScriptElement(): React.ReactHTMLElement<HTMLScriptElement>;
+}

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,56 +1,44 @@
 // TypeScript Version: 2.4
-// export as namespace LoadableComponents;
 
-declare module 'loadable-components' {
-  import * as React from 'react';
+import * as React from 'react';
 
-  interface DefaultImportedComponent<P> {
-    default: React.ComponentType<P>;
-  }
+export as namespace loadable;
 
-  type DefaultComponent<P> = React.ComponentType<P> | DefaultImportedComponent<P>;
+export default function loadable<T>(
+  getComponent: () => Promise<loadable.DefaultComponent<T>>,
+  options?: loadable.LoadableOptions<T>
+): loadable.Loadable<T>;
 
-  export interface ComponentTracker {
-    track: (component: React.Component, modules: any, index?: number) => number;
-
-    get: (id: number) => React.ComponentType;
-    getAll: () => { [key: number]: React.ComponentType };
-    reset: () => void;
-  }
-
-  export interface LoadableOptions<T> {
-    ErrorComponent?: React.ComponentType;
-    LoadingComponent?: React.ComponentType;
-    render?: (options: { loading: boolean, error: boolean, ownProps: T, Component: React.ComponentType<T> }) => React.ReactElement<T>;
-    modules?: any;
-  }
-
-  interface Loadable<T> extends React.ComponentClass<T> {
-    Component: React.ComponentClass;
-    loadingPromise: Promise<any>;
-    load(): Promise<any>;
-  }
-
-  export const componentTracker: ComponentTracker;
-  export const LOADABLE: string;
-
-  export function loadComponents(): Promise<any>;
-
-  export function getState(): { __LOADABLE_STATE__: { children: Array<{ id: number }> } };
-
-  export default function loadable<T>(
-    getComponent: () => Promise<DefaultComponent<T>>,
-    options?: LoadableOptions<T>
-  ): Loadable<T>;
+export interface DefaultImportedComponent<P> {
+  default: React.ComponentType<P>;
 }
 
-declare module 'loadable-components/server' {
-  import * as React from 'react';
+export type DefaultComponent<P> = React.ComponentType<P> | DefaultImportedComponent<P>;
 
-  export function getLoadableState(
-    rootElement: React.ReactElement<{}>,
-    rootContext?: any,
-    fetchRoot?: boolean,
-    tree?: any,
-  ): Promise<any>;
+export interface ComponentTracker {
+  track: (component: React.Component, modules: any, index?: number) => number;
+
+  get: (id: number) => React.ComponentType;
+  getAll: () => { [key: number]: React.ComponentType };
+  reset: () => void;
 }
+
+export interface LoadableOptions<T> {
+  ErrorComponent?: React.ComponentType;
+  LoadingComponent?: React.ComponentType;
+  render?: (options: { loading: boolean, error: boolean, ownProps: T, Component: React.ComponentType<T> }) => React.ReactElement<T>;
+  modules?: any;
+}
+
+export interface Loadable<T> extends React.ComponentClass<T> {
+  Component: React.ComponentClass;
+  loadingPromise: Promise<any>;
+  load(): Promise<any>;
+}
+
+export const componentTracker: ComponentTracker;
+export const LOADABLE: string;
+
+export function loadComponents(): Promise<any>;
+
+export function getState(): { __LOADABLE_STATE__: { children: Array<{ id: number }> } };

--- a/types/test.tsx
+++ b/types/test.tsx
@@ -3,7 +3,7 @@
 
 import * as React from 'react';
 import loadableComponent, { loadComponents } from 'loadable-components';
-import { getLoadableState } from 'loadable-components/server';
+import { DeferredState, getLoadableState } from 'loadable-components/server';
 
 const App = loadableComponent(() => import('./TestComponent'));
 
@@ -13,9 +13,9 @@ const app = (
   <App prop1={"1"} prop2={2}/>
 );
 
-getLoadableState(app).then(() => {
+getLoadableState(app).then((serverState) => {
 // Load all components needed before starting rendering
-  loadComponents().then(() => {
+  loadComponents().then((state) => {
     // $ExpectError
     const a1 = <App prop1={4} prop2="4"/>;
 
@@ -23,5 +23,8 @@ getLoadableState(app).then(() => {
     const a2 = <App/>;
 
     const a3 = <App prop1={"4"} prop2={4}/>;
+
+    // $ExpectType ReactHTMLElement<HTMLScriptElement>
+    const scriptElement = serverState.getScriptElement();
   });
 });

--- a/types/tsconfig.json
+++ b/types/tsconfig.json
@@ -7,6 +7,11 @@
     "noImplicitThis": true,
     "strictNullChecks": true,
     "noEmit": true,
-    "strictFunctionTypes": false
+    "strictFunctionTypes": false,
+    "baseUrl": ".",
+    "paths": {
+      "loadable-components": ["."],
+      "loadable-components/server": ["../server"]
+    }
   }
 }


### PR DESCRIPTION
Hello, I'm trying to use this awesome package with Typescript on the server, and I've had some difficulties. 

When I `import {getLoadableState} from 'loadable-components/server'`, The Typescript compiler complains that it "Could not find a declaration file for module 'loadable-components/server'." I've managed to work around this by explicitly setting the path mapping in tsconfig.json to `"loadable-components/*": ["node_modules/loadable-components/types"]`, but I feel that's an unnecessary step for the end user.

This PR thus extracts the server-side type definitions to a separate `server.d.ts` to match the structure of the JS modules, which seems to be [the recommended way](https://github.com/Microsoft/TypeScript/issues/8305#issuecomment-214815674).

I've also added a type definition for the `DeferredState` which wasn't exposed before.