### PR TITLE
Add a fallback component ID to `loadState`

### DIFF
--- a/src/loadComponents.js
+++ b/src/loadComponents.js
@@ -7,7 +7,10 @@ function loadState(rootState) {
 
   return Promise.all(
     rootState.children.map(state => {
-      const component = componentTracker.get(state.id)
+      const component = typeof state.id === 'string' ?
+        componentTracker.get(state.id) ||
+          componentTracker.get(state.id.substring(0, state.id.lastIndexOf('-'))) :
+        null;
 
       if (!component) {
         console.warn( // eslint-disable-line

--- a/src/loadComponents.test.js
+++ b/src/loadComponents.test.js
@@ -70,4 +70,36 @@ describe('loadComponents', () => {
     expect(Component2.load).toHaveBeenCalled()
     expect(Component3.load).toHaveBeenCalled()
   })
+
+  it('should load all components (simulating server HMR and browser refreshed manually)', async () => {
+    // Because of manually refresh browser, it resets all the state `index`es in
+    // client, i.e. ./Component4 , ./Component5 & ./Component6
+    const Component4 = loadable(async () => () => null)
+    jest.spyOn(Component4, 'load')
+    const id4 = componentTracker.track(Component4, ['./Component4'])
+
+    const id5 = './Component5';
+    const hotServerId5 = `${id5}-1`;
+    const Component5 = loadable(async () => () => null)
+    jest.spyOn(Component5, 'load')
+    componentTracker.track(Component5, [id5])
+
+    const id6 = './Component6';
+    const hotServerId6 = `${id6}-1`;
+    const Component6 = loadable(async () => () => null)
+    jest.spyOn(Component6, 'load')
+    componentTracker.track(Component6, [id6])
+
+    // module states (Component5 & Component6) in server got HMR once
+    // thus the `index`es should be increased by 1, i.e. ./Component5-1 &
+    // ./Component6-1
+    window[LOADABLE_STATE] = {
+      children: [{ id: id4 }, { id: hotServerId5, children: [{ id: hotServerId6 }] }],
+    }
+
+    await loadComponents()
+    expect(Component4.load).toHaveBeenCalled()
+    expect(Component5.load).toHaveBeenCalled()
+    expect(Component6.load).toHaveBeenCalled()
+  })
 })


### PR DESCRIPTION
- Add a fallback component ID (i.e. component name without the index number) to `loadState` to 
  support the situation where HMR done in both server and client then refresh client browser manually.
  Such that it fixes the unmatched component state issue between server and client modules.

- Add a test case for simulating the situation

When hot reloading is done in the server side and manually refreshed the browser, the component ID in the server and client will be out of sync. For example, `./componentA-1` in server and `./componentA` in client.

In this case, `./componentA` is actually the latest version because of the manual refresh, i.e. `./componentA-1` in server since HMR is done in server side and there is no re-build/restart the server.

Thus, the index number in component ID from the server should be ignored in this situation to match the one in client.