### PR TITLE
Add missing import to SSR part of the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,7 @@ You can use them in your application:
 ```js
 // App.js
 import React from 'react'
+import { Route } from 'react-router'
 import { Home } from './Routes'
 
 const App = () => (


### PR DESCRIPTION
That particular sample didn't include the Route import from `react-router`