### PR TITLE
Support non-ES modules

### DIFF
--- a/src/utils/resolveModuleDefault.js
+++ b/src/utils/resolveModuleDefault.js
@@ -1,5 +1,3 @@
-/* eslint-disable no-underscore-dangle */
-const resolveModuleDefault = module =>
-  module.__esModule ? module.default : module
+const resolveModuleDefault = module => module.default || module
 
 export default resolveModuleDefault

--- a/src/utils/resolveModuleDefault.test.js
+++ b/src/utils/resolveModuleDefault.test.js
@@ -1,9 +1,8 @@
 import resolveModuleDefault from './resolveModuleDefault'
 
 describe('resolveModuleDefault', () => {
-  it('should return default is ES module', () => {
+  it('should return default if present', () => {
     const module = {
-      __esModule: true,
       default: 'foo',
     }
 


### PR DESCRIPTION
To fix #103

HOC `loadable` can be used for any modules that webpack can import. I’ve tested it on [my project](https://github.com/sergeysolovev/site) and it works fine for both ES modules and modules containing markdown text.