### PR TITLE
Add server.d.ts to .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,6 +1,7 @@
 /*
 !/babel.js
 !/server.js
+!/server.d.ts
 !/dist/**/*.js
 !/src/**/*.js
 !/types/index.d.ts


### PR DESCRIPTION
#95 broke TS Definitions for `loadable-components/server`. That's because `server.d.ts` is not being exported on npm publish.

This fixes this #112 