### PR TITLE
Exclude http and https from regex. Should fix #153

### DIFF
--- a/packages/server/src/util.js
+++ b/packages/server/src/util.js
@@ -9,4 +9,5 @@ export const smartRequire = modulePath => {
   return require(modulePath)
 }
 
-export const joinURLPath = (...paths) => paths.join('/').replace(/\/\//g, '/')
+export const joinURLPath = (...paths) =>
+  paths.join('/').replace(/(?< !http :| https: ) \/\//g, '/')


### PR DESCRIPTION
The regex now excludes leading http (https). There was a failing test before. Should I look after that one?