### PR TITLE
Remove note about react-loadable (dependent on reactjs.org change).

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,6 @@ Code splitting is supported out of the box by React using [`React.lazy`](https:/
 | `react-loadable`      | ❌       | 🔶  | ❌                | ❌                         |
 | `@loadable/component` | ✅       | ✅  | ✅                | ✅                         |
 
-Even if [`react-loadable` is recommended by React team](https://reactjs.org/docs/code-splitting.html#reactlazy), the project does not accept any GitHub issue and is no longer maintained.
-
 ## Getting started
 
 `loadable` lets you render a dynamic import as a regular component.


### PR DESCRIPTION
## Summary

The React Suspense docs will point to `loadable-components` once https://github.com/reactjs/reactjs.org/pull/1407 is merged, so there will no need to have this line in the README.

I can comment once that PR is merged.