### PR TITLE
fix(webpack-plugin): fix TypeError when set writeToDisk true

### DIFF
--- a/packages/webpack-plugin/src/index.js
+++ b/packages/webpack-plugin/src/index.js
@@ -4,6 +4,9 @@ const fs = require('fs')
 class LoadablePlugin {
   constructor({ filename = 'loadable-stats.json', writeToDisk = false } = {}) {
     this.opts = { filename, writeToDisk }
+
+    // The Webpack compiler instance 
+    this.compiler = null
   }
 
   handleEmit = (hookCompiler, callback) => {
@@ -104,6 +107,8 @@ class LoadablePlugin {
   }
 
   apply(compiler) {
+    this.compiler = compiler
+
     // Add a custom output.jsonpFunction: __LOADABLE_LOADED_CHUNKS__
     compiler.options.output.jsonpFunction = '__LOADABLE_LOADED_CHUNKS__'
 


### PR DESCRIPTION
This is fix for [https://github.com/smooth-code/loadable-components/issues/168](https://github.com/smooth-code/loadable-components/issues/168).