### PR TITLE
fix install command in Server Side Rendering

### DIFF
--- a/website/src/pages/docs/server-side-rendering.mdx
+++ b/website/src/pages/docs/server-side-rendering.mdx
@@ -9,9 +9,9 @@ order: 65
 ## Install
 
 ```bash
-npm install @loadable/server && npm --save-dev @loadable/babel-plugin @loadable/webpack-plugin
+npm install @loadable/server && npm install --save-dev @loadable/babel-plugin @loadable/webpack-plugin
 # or using yarn
-yarn add @loadable/server && yarn --dev @loadable/babel-plugin @loadable/webpack-plugin
+yarn add @loadable/server && yarn add --dev @loadable/babel-plugin @loadable/webpack-plugin
 ```
 
 ## Guide


### PR DESCRIPTION
Found a typo in `Server Side Rendering` part of website.

Added missing `install` and `add` command in installation codes.