### PR TITLE
fix issue with @loadable/webpack-plugin not working in production mode and SSR

### DIFF
--- a/examples/razzle/razzle.config.js
+++ b/examples/razzle/razzle.config.js
@@ -12,7 +12,10 @@ module.exports = {
 
       appConfig.plugins = [
         ...appConfig.plugins,
-        new LoadableWebpackPlugin({ writeToDisk: { filename } }),
+        new LoadableWebpackPlugin({
+          outputAsset: false,
+          writeToDisk: { filename },
+        }),
       ]
     }
 

--- a/examples/razzle/razzle.config.js
+++ b/examples/razzle/razzle.config.js
@@ -8,11 +8,11 @@ module.exports = {
     const appConfig = Object.assign({}, config)
 
     if (target === 'web') {
-      const buildPath = path.resolve(__dirname, 'build')
+      const filename = path.resolve(__dirname, 'build')
 
       appConfig.plugins = [
         ...appConfig.plugins,
-        new LoadableWebpackPlugin({ writeToDisk: true, path: buildPath }),
+        new LoadableWebpackPlugin({ writeToDisk: { filename } }),
       ]
     }
 

--- a/examples/razzle/razzle.config.js
+++ b/examples/razzle/razzle.config.js
@@ -8,11 +8,11 @@ module.exports = {
     const appConfig = Object.assign({}, config)
 
     if (target === 'web') {
-      const filename = path.resolve(__dirname, 'build/loadable-stats.json')
+      const buildPath = path.resolve(__dirname, 'build')
 
       appConfig.plugins = [
         ...appConfig.plugins,
-        new LoadableWebpackPlugin({ writeToDisk: true, filename }),
+        new LoadableWebpackPlugin({ writeToDisk: true, path: buildPath }),
       ]
     }
 

--- a/packages/server/src/util.js
+++ b/packages/server/src/util.js
@@ -5,10 +5,16 @@ export const smartRequire = modulePath => {
     clearModuleCache(modulePath)
   }
 
-  // Use eval to prevent Webpack from compiling it
+  // Use __non_webpack_require__ to prevent Webpack from compiling it
   // when the server-side code is compiled with Webpack
-  // eslint-disable-next-line no-eval
-  return eval('module.require')(modulePath)
+  // eslint-disable-next-line camelcase
+  if (typeof __non_webpack_require__ !== 'undefined') {
+    // eslint-disable-next-line no-undef
+    return __non_webpack_require__(modulePath)
+  }
+
+  // eslint-disable-next-line global-require, import/no-dynamic-require
+  return require(modulePath)
 }
 
 export const joinURLPath = (...paths) => {

--- a/packages/webpack-plugin/README.md
+++ b/packages/webpack-plugin/README.md
@@ -26,11 +26,12 @@ module.exports = {
 
 Create a webpack loadable plugin.
 
-| Arguments             | Description                                       |
-| --------------------- | ------------------------------------------------- |
-| `options`             | Optional options                                  |
-| `options.filename`    | Stats filename (default to `loadable-stats.json`) |
-| `options.writeToDisk` | Always write assets to disk (default to `false`)  |
+| Arguments             | Description                                               |
+| --------------------- | -------------------------------------------------         |
+| `options`             | Optional options                                          |
+| `options.filename`    | Stats filename (default to `loadable-stats.json`)         |
+| `options.path`        | Stats file path (default to webpack config `output.path`) |
+| `options.writeToDisk` | Always write assets to disk (default to `false`)          |
 
 ```js
 new LoadablePlugin({ filename: 'stats.json', writeToDisk: true })

--- a/packages/webpack-plugin/src/index.js
+++ b/packages/webpack-plugin/src/index.js
@@ -5,9 +5,10 @@ class LoadablePlugin {
   constructor({
     filename = 'loadable-stats.json',
     path,
-    writeToDisk = {},
+    writeToDisk,
+    outputAsset = true,
   } = {}) {
-    this.opts = { filename, writeToDisk, path }
+    this.opts = { filename, writeToDisk, outputAsset, path }
 
     // The Webpack compiler instance
     this.compiler = null
@@ -26,17 +27,19 @@ class LoadablePlugin {
     })
     const result = JSON.stringify(stats, null, 2)
 
-    hookCompiler.assets[this.opts.filename] = {
-      source() {
-        return result
-      },
-      size() {
-        return result.length
-      },
+    if (this.opts.outputAsset) {
+      hookCompiler.assets[this.opts.filename] = {
+        source() {
+          return result
+        },
+        size() {
+          return result.length
+        },
+      }
     }
 
-    if (this.opts.writeToDisk.filename) {
-      this.writeAssetsFile(this.opts.writeToDisk.filename, result)
+    if (this.opts.writeToDisk) {
+      this.writeAssetsFile(result)
     }
 
     callback()
@@ -46,7 +49,10 @@ class LoadablePlugin {
    * Write Assets Manifest file
    * @method writeAssetsFile
    */
-  writeAssetsFile = (outputFolder, manifest) => {
+  writeAssetsFile = manifest => {
+    const outputFolder =
+      this.opts.writeToDisk.filename || this.compiler.options.output.path
+
     const outputFile = nodePath.resolve(outputFolder, this.opts.filename)
 
     try {

--- a/packages/webpack-plugin/src/index.js
+++ b/packages/webpack-plugin/src/index.js
@@ -1,9 +1,13 @@
-const path = require('path')
+const nodePath = require('path')
 const fs = require('fs')
 
 class LoadablePlugin {
-  constructor({ filename = 'loadable-stats.json', writeToDisk = false } = {}) {
-    this.opts = { filename, writeToDisk }
+  constructor({
+    filename = 'loadable-stats.json',
+    path,
+    writeToDisk = false,
+  } = {}) {
+    this.opts = { filename, writeToDisk, path }
 
     // The Webpack compiler instance
     this.compiler = null
@@ -32,70 +36,23 @@ class LoadablePlugin {
     }
 
     if (this.opts.writeToDisk) {
-      this.writeAssetsFile(result)
+      const outputFolder = this.opts.path || hookCompiler.options.output.path
+      this.writeAssetsFile(outputFolder, result)
     }
 
     callback()
   }
 
   /**
-   * Check if request is from Dev Server
-   * aka webpack-dev-server
-   * @method isRequestFromDevServer
-   * @returns {boolean} - True or False
-   */
-  isRequestFromDevServer = () => {
-    if (process.argv.some(arg => arg.includes('webpack-dev-server'))) {
-      return true
-    }
-    return (
-      this.compiler.outputFileSystem &&
-      this.compiler.outputFileSystem.constructor.name === 'MemoryFileSystem'
-    )
-  }
-
-  /**
-   * Get assets manifest output path
-   *
-   * @method getManifestOutputPath
-   * @returns {string} - Output path containing path + filename.
-   */
-  getManifestOutputPath = () => {
-    if (path.isAbsolute(this.opts.filename)) {
-      return this.opts.filename
-    }
-
-    if (this.isRequestFromDevServer() && this.compiler.options.devServer) {
-      let outputPath =
-        this.compiler.options.devServer.outputPath ||
-        this.compiler.outputPath ||
-        '/'
-
-      if (outputPath === '/') {
-        // eslint-disable-next-line no-console
-        console.warn(
-          'Please use an absolute path in options.output when using webpack-dev-server.',
-        )
-        outputPath = this.compiler.context || process.cwd()
-      }
-
-      return path.resolve(outputPath, this.opts.filename)
-    }
-
-    return path.resolve(this.compiler.outputPath, this.opts.filename)
-  }
-
-  /**
    * Write Assets Manifest file
    * @method writeAssetsFile
    */
-  writeAssetsFile = manifest => {
-    const filePath = this.getManifestOutputPath()
-    const fileDir = path.dirname(filePath)
+  writeAssetsFile = (outputFolder, manifest) => {
+    const outputFile = nodePath.resolve(outputFolder, this.opts.filename)
 
     try {
-      if (!fs.existsSync(fileDir)) {
-        fs.mkdirSync(fileDir)
+      if (!fs.existsSync(outputFolder)) {
+        fs.mkdirSync(outputFolder)
       }
     } catch (err) {
       if (err.code !== 'EEXIST') {
@@ -103,7 +60,7 @@ class LoadablePlugin {
       }
     }
 
-    fs.writeFileSync(filePath, manifest)
+    fs.writeFileSync(outputFile, manifest)
   }
 
   apply(compiler) {

--- a/packages/webpack-plugin/src/index.js
+++ b/packages/webpack-plugin/src/index.js
@@ -5,7 +5,7 @@ class LoadablePlugin {
   constructor({
     filename = 'loadable-stats.json',
     path,
-    writeToDisk = false,
+    writeToDisk = {},
   } = {}) {
     this.opts = { filename, writeToDisk, path }
 
@@ -35,9 +35,8 @@ class LoadablePlugin {
       },
     }
 
-    if (this.opts.writeToDisk) {
-      const outputFolder = this.opts.path || hookCompiler.options.output.path
-      this.writeAssetsFile(outputFolder, result)
+    if (this.opts.writeToDisk.filename) {
+      this.writeAssetsFile(this.opts.writeToDisk.filename, result)
     }
 
     callback()

--- a/website/src/pages/docs/api-loadable-webpack-plugin.mdx
+++ b/website/src/pages/docs/api-loadable-webpack-plugin.mdx
@@ -10,11 +10,10 @@ order: 30
 
 Create a webpack loadable plugin.
 
-| Arguments             | Description                                       |
-| --------------------- | ------------------------------------------------- |
-| `options`             | Optional options                                  |
-| `options.filename`    | Stats filename (default to `loadable-stats.json`) |
-| `options.writeToDisk` | Always write assets to disk (default to `false`)  |
+| Arguments                      | Description                                       |
+| ------------------------------ | ------------------------------------------------- |
+| `options`                      | Optional options                                  |
+| `options.writeToDisk.filename` | Write assets to disk at given `filename` location |
 
 ```js
 new LoadablePlugin({ filename: 'stats.json', writeToDisk: true })


### PR DESCRIPTION
This is my stab at https://github.com/smooth-code/loadable-components/issues/179 .

I've added `path` option to the webpack plugin, that allows specifying where loadable-stats are written to when `writeToDisk` option is set to true. This way webpack assets compiler always use `filename` and not absolute path when adding loadable stats to the assets. If `path` is not set by default loadable-stats are written to `output.path` set in webpack config.

I also fixed issue I had with `eval('module.require')` trick as it was throwing errors (eval is not a function). I've replaced it with `__non_webpack_require__` and that seems to be working fine.

I've tested it with razzle example in the repo and it works fine both in dev and production mode (after yarn build command).

Closes https://github.com/smooth-code/loadable-components/issues/179