### PR TITLE
Inline CSS options

### DIFF
--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -276,12 +276,32 @@ Get style links as a string of `<link>` tags.
 const head = `<head>${chunkExtractor.getStyleTags()}</head>`
 ```
 
+Get inline style links as a string of `<link>` tags.
+
+```js
+const head = `<head>${chunkExtractor.getStyleTags({ inline: true })}</head>`
+```
+
 ### chunkExtractor.getStyleElements
 
 Get style links as an array of React `<link>` elements.
 
 ```js
 const head = renderToString(<head>{chunkExtractor.getStyleElements()}</head>)
+```
+
+Get inline style links as an array of React `<link>` elements.
+
+```js
+const head = renderToString(<head>{chunkExtractor.getStyleElements({ inline: true })}</head>)
+```
+
+### chunkExtractor.getCssString
+
+Get css as a raw string for using directly within app (e.g. in custom AMP style tag)
+
+```js
+const cssString = chunkExtractor.getCssString()
 ```
 
 ### ChunkExtractorManager

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -276,10 +276,12 @@ Get style links as a string of `<link>` tags.
 const head = `<head>${chunkExtractor.getStyleTags()}</head>`
 ```
 
+### chunkExtractor.getInlineStyleTags
+
 Get inline style links as a string of `<link>` tags (returns a promise).
 
 ```js
-chunkExtractor.getStyleTags({ inline: true })
+chunkExtractor.getInlineStyleTags()
 .then((styleTags) => {
   const head = `<head>${styleTags}</head>`
 }
@@ -293,10 +295,12 @@ Get style links as an array of React `<link>` elements.
 const head = renderToString(<head>{chunkExtractor.getStyleElements()}</head>)
 ```
 
+### chunkExtractor.getInlineStyleElements
+
 Get inline style links as an array of React `<link>` elements (returns a promise).
 
 ```js
-chunkExtractor.getStyleElements({ inline: true })
+chunkExtractor.getInlineStyleElements()
 .then((styleElements) => {
   const head = renderToString(<head>{styleElements}</head>)
 }

--- a/packages/server/__fixtures__/letters-A.css
+++ b/packages/server/__fixtures__/letters-A.css
@@ -1,0 +1,3 @@
+body {
+  background: pink;
+}

--- a/packages/server/__fixtures__/main.css
+++ b/packages/server/__fixtures__/main.css
@@ -1,0 +1,3 @@
+h1 {
+  color: cyan;
+}

--- a/packages/server/src/ChunkExtractor.js
+++ b/packages/server/src/ChunkExtractor.js
@@ -35,7 +35,10 @@ function assetToScriptElement(asset) {
 function assetToStyleString(asset) {
   return new Promise((resolve, reject) => {
     fs.readFile(asset.path, 'utf8', (err, data) => {
-      if (err) reject(err)
+      if (err) {
+        reject(err);
+        return;
+      }
       resolve(data);
     })
   })
@@ -50,7 +53,10 @@ function assetToStyleTag(asset) {
 function assetToStyleTagInline(asset) {
   return new Promise((resolve, reject) => {
     fs.readFile(asset.path, 'utf8', (err, data) => {
-      if (err) reject(err)
+      if (err) {
+        reject(err);
+        return;
+      }
       resolve(
         `<style data-chunk="${asset.chunk}">
         ${data}
@@ -75,7 +81,10 @@ function assetToStyleElement(asset) {
 function assetToStyleElementInline(asset) {
   return new Promise((resolve, reject) => {
     fs.readFile(asset.path, 'utf8', (err, data) => {
-      if (err) reject(err)
+      if (err) {
+        reject(err);
+        return;
+      }
       resolve(
         <style
           key={asset.url}

--- a/packages/server/src/ChunkExtractor.js
+++ b/packages/server/src/ChunkExtractor.js
@@ -1,5 +1,6 @@
 /* eslint-disable react/no-danger */
 import path from 'path'
+import fs from 'fs'
 import _ from 'lodash'
 import React from 'react'
 import { invariant, LOADABLE_REQUIRED_CHUNKS_KEY } from './sharedInternals'
@@ -44,6 +45,16 @@ function assetToStyleElement(asset) {
       data-chunk={asset.chunk}
       rel="stylesheet"
       href={asset.url}
+    />
+  )
+}
+
+function assetToStyleElementInline(asset) {
+  return (
+    <style
+      key={asset.url}
+      data-chunk={asset.chunk}
+      dangerouslySetInnerHTML={{ __html: fs.readFileSync(asset.path, 'utf8') }} 
     />
   )
 }
@@ -248,10 +259,15 @@ class ChunkExtractor {
     const mainAssets = this.getMainAssets('style')
     return joinTags(mainAssets.map(asset => assetToStyleTag(asset)))
   }
-
+  
   getStyleElements() {
     const mainAssets = this.getMainAssets('style')
     return mainAssets.map(asset => assetToStyleElement(asset))
+  }
+
+  getStyleInlineElements() {
+    const mainAssets = this.getMainAssets('style')
+    return mainAssets.map(asset => assetToStyleElementInline(asset))
   }
 
   // Pre assets

--- a/packages/server/src/ChunkExtractor.js
+++ b/packages/server/src/ChunkExtractor.js
@@ -289,26 +289,26 @@ class ChunkExtractor {
     return Promise.all(promises).then(results => joinTags(results))
   }
 
-  getStyleTags(options = {
-    inline: false,
-  }) {
+  getStyleTags() {
     const mainAssets = this.getMainAssets('style')
-    if (options.inline === true) {
-      const promises = mainAssets.map((asset) => assetToStyleTagInline(asset).then(data => data))
-      return Promise.all(promises).then(results => joinTags(results))
-    }
     return joinTags(mainAssets.map(asset => assetToStyleTag(asset)))
   }
-  
-  getStyleElements(options = {
-    inline: false,
-  }) {
+
+  getInlineStyleTags() {
     const mainAssets = this.getMainAssets('style')
-    if (options.inline === true) {
-      const promises = mainAssets.map((asset) => assetToStyleElementInline(asset).then(data => data))
-      return Promise.all(promises).then(results => results)
-    }
+    const promises = mainAssets.map((asset) => assetToStyleTagInline(asset).then(data => data))
+    return Promise.all(promises).then(results => joinTags(results))
+  }
+  
+  getStyleElements() {
+    const mainAssets = this.getMainAssets('style')
     return mainAssets.map(asset => assetToStyleElement(asset))
+  }
+  
+  getInlineStyleElements() {
+    const mainAssets = this.getMainAssets('style')
+    const promises = mainAssets.map((asset) => assetToStyleElementInline(asset).then(data => data))
+    return Promise.all(promises).then(results => results)
   }
 
   // Pre assets

--- a/packages/server/src/ChunkExtractor.js
+++ b/packages/server/src/ChunkExtractor.js
@@ -32,10 +32,21 @@ function assetToScriptElement(asset) {
   )
 }
 
+function assetToStyleString(asset) {
+  return fs.readFileSync(asset.path, 'utf8');
+}
+
 function assetToStyleTag(asset) {
   return `<link data-chunk="${asset.chunk}" rel="stylesheet" href="${
     asset.url
   }">`
+}
+
+function assetToStyleTagInline(asset) {
+  return `<style data-chunk="${asset.chunk}">
+  ${fs.readFileSync(asset.path, 'utf8')}
+  </style>
+  `
 }
 
 function assetToStyleElement(asset) {
@@ -54,7 +65,7 @@ function assetToStyleElementInline(asset) {
     <style
       key={asset.url}
       data-chunk={asset.chunk}
-      dangerouslySetInnerHTML={{ __html: fs.readFileSync(asset.path, 'utf8') }} 
+      dangerouslySetInnerHTML={{ __html: fs.readFileSync(asset.path, 'utf8') }}
     />
   )
 }
@@ -255,19 +266,29 @@ class ChunkExtractor {
     return [requiredScriptElement, ...assetsScriptElements]
   }
 
-  getStyleTags() {
+  getCssString() {
     const mainAssets = this.getMainAssets('style')
+    return joinTags(mainAssets.map(asset => assetToStyleString(asset)))
+  }
+
+  getStyleTags(options = {
+    inline: false,
+  }) {
+    const mainAssets = this.getMainAssets('style')
+    if (options.inline === true) {
+      return mainAssets.map(asset => assetToStyleTagInline(asset))
+    }
     return joinTags(mainAssets.map(asset => assetToStyleTag(asset)))
   }
   
-  getStyleElements() {
+  getStyleElements(options = {
+    inline: false,
+  }) {
     const mainAssets = this.getMainAssets('style')
+    if (options.inline === true) {
+      return mainAssets.map(asset => assetToStyleElementInline(asset))
+    }
     return mainAssets.map(asset => assetToStyleElement(asset))
-  }
-
-  getStyleInlineElements() {
-    const mainAssets = this.getMainAssets('style')
-    return mainAssets.map(asset => assetToStyleElementInline(asset))
   }
 
   // Pre assets

--- a/packages/server/src/ChunkExtractor.test.js
+++ b/packages/server/src/ChunkExtractor.test.js
@@ -119,10 +119,13 @@ Array [
 `)
     })
 
-    it('should return inline style tags with inline option parameter as a promise', () => {
+  })
+
+  describe('#getInlineStyleTags', () => {
+    it('should return inline style tags as a promise', () => {
       extractor.addChunk('letters-A')
       expect.assertions(1)
-      return extractor.getStyleTags({ inline: true }).then(data => expect(data).toMatchInlineSnapshot(`
+      return extractor.getInlineStyleTags().then(data => expect(data).toMatchInlineSnapshot(`
 "<style data-chunk=\\"letters-A\\">
         body {
   background: pink;
@@ -173,10 +176,13 @@ Array [
 `)
     })
 
-    it('should return inline style elements with inline option parameter as a promise', () => {
+  })
+
+  describe('#getInlineStyleElements', () => {
+    it('should return inline style elements as a promise', () => {
       extractor.addChunk('letters-A')
       expect.assertions(1)
-      return extractor.getStyleElements({ inline: true }).then(data => expect(data).toMatchInlineSnapshot(`
+      return extractor.getInlineStyleElements().then(data => expect(data).toMatchInlineSnapshot(`
 Array [
   <style
     dangerouslySetInnerHTML={

--- a/packages/server/src/ChunkExtractor.test.js
+++ b/packages/server/src/ChunkExtractor.test.js
@@ -15,7 +15,7 @@ describe('ChunkExtrator', () => {
   describe('#stats', () => {
     it('should load stats from file', () => {
       extractor = new ChunkExtractor({
-        statsFile: path.resolve(__dirname, '../__fixtures__/stats'),
+        statsFile: path.resolve(__dirname, '../__fixtures__/stats.json'),
       })
 
       expect(extractor.stats).toBe(stats)

--- a/packages/server/src/ChunkExtractor.test.js
+++ b/packages/server/src/ChunkExtractor.test.js
@@ -1,5 +1,5 @@
 import path from 'path'
-import stats from '../__fixtures__/stats'
+import stats from '../__fixtures__/stats.json'
 import ChunkExtractor from './ChunkExtractor'
 
 describe('ChunkExtrator', () => {

--- a/packages/server/src/ChunkExtractor.test.js
+++ b/packages/server/src/ChunkExtractor.test.js
@@ -1,32 +1,38 @@
 import path from 'path'
-import stats from '../__fixtures__/stats.json'
+import stats from '../__fixtures__/stats'
 import ChunkExtractor from './ChunkExtractor'
 
 describe('ChunkExtrator', () => {
+  let extractor
+
+  beforeEach(() => {
+    extractor = new ChunkExtractor({
+      stats,
+      outputPath: path.resolve(__dirname, '../__fixtures__'),
+    })
+  })
+
   describe('#stats', () => {
     it('should load stats from file', () => {
-      const extractor = new ChunkExtractor({
-        statsFile: path.resolve(__dirname, '../__fixtures__/stats.json'),
+      extractor = new ChunkExtractor({
+        statsFile: path.resolve(__dirname, '../__fixtures__/stats'),
       })
 
       expect(extractor.stats).toBe(stats)
     })
 
     it('should load stats from stats', () => {
-      const extractor = new ChunkExtractor({ stats })
       expect(extractor.stats).toBe(stats)
     })
   })
 
   describe('#addChunk', () => {
     it('should reference chunk', () => {
-      const extractor = new ChunkExtractor({ stats })
       extractor.addChunk('foo')
       expect(extractor.chunks).toEqual(['foo'])
     })
 
     it('should be uniq', () => {
-      const extractor = new ChunkExtractor({ stats })
       extractor.addChunk('a')
       extractor.addChunk('b')
       extractor.addChunk('b')
@@ -36,7 +42,6 @@ describe('ChunkExtrator', () => {
 
   describe('#getScriptTags', () => {
     it('should return main script tag without chunk', () => {
-      const extractor = new ChunkExtractor({ stats })
       expect(extractor.getScriptTags()).toMatchInlineSnapshot(`
 "<script>window.__LOADABLE_REQUIRED_CHUNKS__ = [];</script>
 <script async data-chunk=\\"main\\" src=\\"/dist/node/main.js\\"></script>"
@@ -44,7 +49,6 @@ describe('ChunkExtrator', () => {
     })
 
     it('should return other chunks if referenced', () => {
-      const extractor = new ChunkExtractor({ stats })
       extractor.addChunk('letters-A')
       expect(extractor.getScriptTags()).toMatchInlineSnapshot(`
 "<script>window.__LOADABLE_REQUIRED_CHUNKS__ = [\\"letters-A\\"];</script>
@@ -56,7 +60,6 @@ describe('ChunkExtrator', () => {
 
   describe('#getScriptElements', () => {
     it('should return main script tag without chunk', () => {
-      const extractor = new ChunkExtractor({ stats })
       expect(extractor.getScriptElements()).toMatchInlineSnapshot(`
 Array [
   <script
@@ -76,7 +79,6 @@ Array [
     })
 
     it('should return other chunks if referenced', () => {
-      const extractor = new ChunkExtractor({ stats })
       extractor.addChunk('letters-A')
       expect(extractor.getScriptElements()).toMatchInlineSnapshot(`
 Array [
@@ -104,25 +106,43 @@ Array [
 
   describe('#getStyleTags', () => {
     it('should return main style tag without chunk', () => {
-      const extractor = new ChunkExtractor({ stats })
       expect(extractor.getStyleTags()).toMatchInlineSnapshot(
         `"<link data-chunk=\\"main\\" rel=\\"stylesheet\\" href=\\"/dist/node/main.css\\">"`,
       )
     })
 
     it('should return other chunks if referenced', () => {
-      const extractor = new ChunkExtractor({ stats })
       extractor.addChunk('letters-A')
       expect(extractor.getStyleTags()).toMatchInlineSnapshot(`
 "<link data-chunk=\\"letters-A\\" rel=\\"stylesheet\\" href=\\"/dist/node/letters-A.css\\">
 <link data-chunk=\\"main\\" rel=\\"stylesheet\\" href=\\"/dist/node/main.css\\">"
 `)
     })
+
+    it('should return inline style tags with inline option parameter', () => {
+      extractor.addChunk('letters-A')
+      expect(extractor.getStyleTags({ inline: true })).toMatchInlineSnapshot(`
+Array [
+  "<style data-chunk=\\"letters-A\\">
+  body {
+  background: pink;
+}
+
+  </style>
+  ",
+  "<style data-chunk=\\"main\\">
+  h1 {
+  color: cyan;
+}
+  </style>
+  ",
+]
+`)
+    })
   })
 
   describe('#getStyleElements', () => {
     it('should return main style tag without chunk', () => {
-      const extractor = new ChunkExtractor({ stats })
       expect(extractor.getStyleElements()).toMatchInlineSnapshot(`
 Array [
   <link
@@ -135,7 +155,6 @@ Array [
     })
 
     it('should return other chunks if referenced', () => {
-      const extractor = new ChunkExtractor({ stats })
       extractor.addChunk('letters-A')
       expect(extractor.getStyleElements()).toMatchInlineSnapshot(`
 Array [
@@ -152,11 +171,55 @@ Array [
 ]
 `)
     })
+
+    it('should return inline style tags with inline option parameter', () => {
+      extractor.addChunk('letters-A')
+      expect(extractor.getStyleElements({ inline: true }))
+        .toMatchInlineSnapshot(`
+Array [
+  <style
+    dangerouslySetInnerHTML={
+      Object {
+        "__html": "body {
+  background: pink;
+}
+",
+      }
+    }
+    data-chunk="letters-A"
+  />,
+  <style
+    dangerouslySetInnerHTML={
+      Object {
+        "__html": "h1 {
+  color: cyan;
+}",
+      }
+    }
+    data-chunk="main"
+  />,
+]
+`)
+    })
+  })
+
+  describe('#getCssString', () => {
+    it('should return a string of the referenced css files', () => {
+      extractor.addChunk('letters-A')
+      expect(extractor.getCssString()).toMatchInlineSnapshot(`
+"body {
+  background: pink;
+}
+
+h1 {
+  color: cyan;
+}"
+`)
+    })
   })
 
   describe('#getLinkTags', () => {
     it('should return main script tag without chunk', () => {
-      const extractor = new ChunkExtractor({ stats })
       expect(extractor.getLinkTags()).toMatchInlineSnapshot(`
 "<link data-chunk=\\"main\\" rel=\\"preload\\" as=\\"style\\" href=\\"/dist/node/main.css\\">
 <link data-chunk=\\"main\\" rel=\\"preload\\" as=\\"script\\" href=\\"/dist/node/main.js\\">
@@ -166,7 +229,6 @@ Array [
     })
 
     it('should return other chunks if referenced', () => {
-      const extractor = new ChunkExtractor({ stats })
       extractor.addChunk('letters-A')
       expect(extractor.getLinkTags()).toMatchInlineSnapshot(`
 "<link data-chunk=\\"letters-A\\" rel=\\"preload\\" as=\\"style\\" href=\\"/dist/node/letters-A.css\\">
@@ -181,7 +243,6 @@ Array [
 
   describe('#getLinkElements', () => {
     it('should return main script tag without chunk', () => {
-      const extractor = new ChunkExtractor({ stats })
       expect(extractor.getLinkElements()).toMatchInlineSnapshot(`
 Array [
   <link
@@ -213,7 +274,6 @@ Array [
     })
 
     it('should return other chunks if referenced', () => {
-      const extractor = new ChunkExtractor({ stats })
       extractor.addChunk('letters-A')
       expect(extractor.getLinkElements()).toMatchInlineSnapshot(`
 Array [
@@ -260,7 +320,6 @@ Array [
 
   describe('#requireEntryPoint', () => {
     it('should load the first entrypoint', () => {
-      const extractor = new ChunkExtractor({ stats })
       const x = extractor.requireEntrypoint()
       expect(x).toBe('hello')
     })


### PR DESCRIPTION
Hi. We have a requirement to render our css inline in certain situations, and so I had a crack at implementing it with the loadable library. Please do let me know what you think about the approach.

## Summary

In order to improve page speed score, or to render AMP SSR pages alongside the main app, it can be a requirement to render css inline.

## Test plan

This has been added as an option to the existing `chunkExtractor.getStyleTags()` and `chunkExtractor.getStyleElements()` functions via an `inline` boolean parameter. 

Additionally a `chunkExtractor.getCssString()` function has been added to allow developers further control over how to render css (an example use requirement being passing the css string to a style tag using AMP's `amp-custom` attribute)

Appropriate tests have been added to `ChunkExtractor.test.js`
