### PR TITLE
Remove express-async-handler dependency from server-side-rendering example

### DIFF
--- a/examples/server-side-rendering/package.json
+++ b/examples/server-side-rendering/package.json
@@ -24,7 +24,6 @@
   },
   "dependencies": {
     "express": "^4.16.4",
-    "express-async-handler": "^1.1.4",
     "moment": "^2.22.2",
     "react": "^16.6.0",
     "react-dom": "^16.6.0"

--- a/examples/server-side-rendering/src/server/main.js
+++ b/examples/server-side-rendering/src/server/main.js
@@ -2,7 +2,6 @@ import path from 'path'
 import express from 'express'
 import React from 'react'
 import { renderToString } from 'react-dom/server'
-import asyncHandler from 'express-async-handler'
 import { ChunkExtractor } from '@loadable/server'
 
 const app = express()
@@ -41,7 +40,7 @@ const webStats = path.resolve(
 
 app.get(
   '*',
-  asyncHandler(async (req, res) => {
+  (req, res) => {
     const nodeExtractor = new ChunkExtractor({ statsFile: nodeStats })
     const { default: App } = nodeExtractor.requireEntrypoint()
 
@@ -62,7 +61,7 @@ ${webExtractor.getStyleTags()}
   ${webExtractor.getScriptTags()}
 </body>
 </html>`)
-  }),
+  },
 )
 
 // eslint-disable-next-line no-console

--- a/examples/server-side-rendering/yarn.lock
+++ b/examples/server-side-rendering/yarn.lock
@@ -1274,11 +1274,6 @@ expand-brackets@^2.1.4:
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
 
-express-async-handler@^1.1.4:
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/express-async-handler/-/express-async-handler-1.1.4.tgz#225a84908df63b35ae9df94b6f0f1af061266426"
-  integrity sha512-HdmbVF4V4w1q/iz++RV7bUxIeepTukWewiJGkoCKQMtvPF11MLTa7It9PRc/reysXXZSEyD4Pthchju+IUbMiQ==
-
 express@^4.16.4:
   version "4.16.4"
   resolved "https://registry.yarnpkg.com/express/-/express-4.16.4.tgz#fddef61926109e24c515ea97fd2f1bdbf62df12e"


### PR DESCRIPTION
## Summary

This PR removes an used dependency from the server-side-rendering example.

## Test plan

n/a