### PR TITLE
Allow to specify extra attribute in getScriptTags

### DIFF
--- a/packages/server/src/ChunkExtractor.js
+++ b/packages/server/src/ChunkExtractor.js
@@ -30,9 +30,9 @@ function assetToScriptTag(asset, extraProps) {
   }"${extraPropsToString(extraProps)}></script>`
 }
 
-function assetToScriptElement(asset) {
+function assetToScriptElement(asset, extraProps) {
   return (
-    <script key={asset.url} async data-chunk={asset.chunk} src={asset.url} />
+    <script key={asset.url} async data-chunk={asset.chunk} src={asset.url} {...extraProps} />
   )
 }
 
@@ -233,13 +233,14 @@ class ChunkExtractor {
     return `<script${extraPropsToString(extraProps)}>${this.getRequiredChunksScriptContent()}</script>`
   }
 
-  getRequiredChunksScriptElement() {
+  getRequiredChunksScriptElement(extraProps) {
     return (
       <script
         key="required"
         dangerouslySetInnerHTML={{
           __html: this.getRequiredChunksScriptContent(),
         }}
+        {...extraProps}
       />
     )
   }
@@ -279,18 +280,18 @@ class ChunkExtractor {
     return assets
   }
 
-  getScriptTags(extraProps = {} ) {
+  getScriptTags(extraProps = {}) {
     const requiredScriptTag = this.getRequiredChunksScriptTag(extraProps)
     const mainAssets = this.getMainAssets('script')
     const assetsScriptTags = mainAssets.map(asset => assetToScriptTag(asset, extraProps))
     return joinTags([requiredScriptTag, ...assetsScriptTags])
   }
 
-  getScriptElements() {
-    const requiredScriptElement = this.getRequiredChunksScriptElement()
+  getScriptElements(extraProps = {}) {
+    const requiredScriptElement = this.getRequiredChunksScriptElement(extraProps)
     const mainAssets = this.getMainAssets('script')
     const assetsScriptElements = mainAssets.map(asset =>
-      assetToScriptElement(asset),
+      assetToScriptElement(asset, extraProps),
     )
     return [requiredScriptElement, ...assetsScriptElements]
   }

--- a/packages/server/src/ChunkExtractor.js
+++ b/packages/server/src/ChunkExtractor.js
@@ -20,10 +20,14 @@ function getAssets(chunks, getAsset) {
   return _.uniqBy(_.flatMap(chunks, chunk => getAsset(chunk)), 'url')
 }
 
-function assetToScriptTag(asset) {
+function extraPropsToString(extraProps) {
+  return Object.keys(extraProps).reduce((acc, key) => `${acc} ${key}="${extraProps[key]}"`, '');
+}
+
+function assetToScriptTag(asset, extraProps) {
   return `<script async data-chunk="${asset.chunk}" src="${
     asset.url
-  }"></script>`
+  }"${extraPropsToString(extraProps)}></script>`
 }
 
 function assetToScriptElement(asset) {
@@ -225,8 +229,8 @@ class ChunkExtractor {
     )};`
   }
 
-  getRequiredChunksScriptTag() {
-    return `<script>${this.getRequiredChunksScriptContent()}</script>`
+  getRequiredChunksScriptTag(extraProps) {
+    return `<script${extraPropsToString(extraProps)}>${this.getRequiredChunksScriptContent()}</script>`
   }
 
   getRequiredChunksScriptElement() {
@@ -275,10 +279,10 @@ class ChunkExtractor {
     return assets
   }
 
-  getScriptTags() {
-    const requiredScriptTag = this.getRequiredChunksScriptTag()
+  getScriptTags(extraProps = {} ) {
+    const requiredScriptTag = this.getRequiredChunksScriptTag(extraProps)
     const mainAssets = this.getMainAssets('script')
-    const assetsScriptTags = mainAssets.map(asset => assetToScriptTag(asset))
+    const assetsScriptTags = mainAssets.map(asset => assetToScriptTag(asset, extraProps))
     return joinTags([requiredScriptTag, ...assetsScriptTags])
   }
 

--- a/packages/server/src/ChunkExtractor.js
+++ b/packages/server/src/ChunkExtractor.js
@@ -48,13 +48,13 @@ function assetToStyleString(asset) {
   })
 }
 
-function assetToStyleTag(asset) {
+function assetToStyleTag(asset, extraProps) {
   return `<link data-chunk="${asset.chunk}" rel="stylesheet" href="${
     asset.url
-  }">`
+  }"${extraPropsToString(extraProps)}>`
 }
 
-function assetToStyleTagInline(asset) {
+function assetToStyleTagInline(asset, extraProps) {
   return new Promise((resolve, reject) => {
     fs.readFile(asset.path, 'utf8', (err, data) => {
       if (err) {
@@ -62,7 +62,7 @@ function assetToStyleTagInline(asset) {
         return
       }
       resolve(
-        `<style type="text/css" data-chunk="${asset.chunk}">
+        `<style type="text/css" data-chunk="${asset.chunk}"${extraPropsToString(extraProps)}>
 ${data}
 </style>`,
       )
@@ -70,18 +70,19 @@ ${data}
   })
 }
 
-function assetToStyleElement(asset) {
+function assetToStyleElement(asset, extraProps) {
   return (
     <link
       key={asset.url}
       data-chunk={asset.chunk}
       rel="stylesheet"
       href={asset.url}
+      {...extraProps}
     />
   )
 }
 
-function assetToStyleElementInline(asset) {
+function assetToStyleElementInline(asset, extraProps) {
   return new Promise((resolve, reject) => {
     fs.readFile(asset.path, 'utf8', (err, data) => {
       if (err) {
@@ -93,6 +94,7 @@ function assetToStyleElementInline(asset) {
           key={asset.url}
           data-chunk={asset.chunk}
           dangerouslySetInnerHTML={{ __html: data }}
+          {...extraProps}
         />,
       )
     })
@@ -304,28 +306,28 @@ class ChunkExtractor {
     return Promise.all(promises).then(results => joinTags(results))
   }
 
-  getStyleTags() {
+  getStyleTags(extraProps = {}) {
     const mainAssets = this.getMainAssets('style')
-    return joinTags(mainAssets.map(asset => assetToStyleTag(asset)))
+    return joinTags(mainAssets.map(asset => assetToStyleTag(asset, extraProps)))
   }
 
-  getInlineStyleTags() {
+  getInlineStyleTags(extraProps = {}) {
     const mainAssets = this.getMainAssets('style')
     const promises = mainAssets.map(asset =>
-      assetToStyleTagInline(asset).then(data => data),
+      assetToStyleTagInline(asset, extraProps).then(data => data),
     )
     return Promise.all(promises).then(results => joinTags(results))
   }
 
-  getStyleElements() {
+  getStyleElements(extraProps = {}) {
     const mainAssets = this.getMainAssets('style')
-    return mainAssets.map(asset => assetToStyleElement(asset))
+    return mainAssets.map(asset => assetToStyleElement(asset, extraProps))
   }
 
-  getInlineStyleElements() {
+  getInlineStyleElements(extraProps = {}) {
     const mainAssets = this.getMainAssets('style')
     const promises = mainAssets.map(asset =>
-      assetToStyleElementInline(asset).then(data => data),
+      assetToStyleElementInline(asset, extraProps).then(data => data),
     )
     return Promise.all(promises).then(results => results)
   }

--- a/packages/server/src/ChunkExtractor.test.js
+++ b/packages/server/src/ChunkExtractor.test.js
@@ -112,6 +112,35 @@ Array [
 ]
 `)
     })
+
+    it('should add extra props if specified', () => {
+      extractor.addChunk('letters-A')
+      expect(extractor.getScriptElements({ nonce: 'testnonce' }))
+        .toMatchInlineSnapshot(`
+Array [
+  <script
+    dangerouslySetInnerHTML={
+      Object {
+        "__html": "window.__LOADABLE_REQUIRED_CHUNKS__ = [\\"letters-A\\"];",
+      }
+    }
+    nonce="testnonce"
+  />,
+  <script
+    async={true}
+    data-chunk="letters-A"
+    nonce="testnonce"
+    src="/dist/node/letters-A.js"
+  />,
+  <script
+    async={true}
+    data-chunk="main"
+    nonce="testnonce"
+    src="/dist/node/main.js"
+  />,
+]
+`)
+    })
   })
 
   describe('#getStyleTags', () => {

--- a/packages/server/src/ChunkExtractor.test.js
+++ b/packages/server/src/ChunkExtractor.test.js
@@ -157,6 +157,15 @@ Array [
 <link data-chunk=\\"main\\" rel=\\"stylesheet\\" href=\\"/dist/node/main.css\\">"
 `)
     })
+
+    it('should add extraProps if specified', () => {
+      extractor.addChunk('letters-A')
+      expect(extractor.getStyleTags({ nonce: 'testnonce' }))
+        .toMatchInlineSnapshot(`
+"<link data-chunk=\\"letters-A\\" rel=\\"stylesheet\\" href=\\"/dist/node/letters-A.css\\" nonce=\\"testnonce\\">
+<link data-chunk=\\"main\\" rel=\\"stylesheet\\" href=\\"/dist/node/main.css\\" nonce=\\"testnonce\\">"
+`)
+    })
   })
 
   describe('#getInlineStyleTags', () => {
@@ -172,6 +181,26 @@ body {
 
 </style>
 <style type=\\"text/css\\" data-chunk=\\"main\\">
+h1 {
+  color: cyan;
+}
+</style>"
+`),
+      )
+    })
+
+    it('should add extraProps if specified', () => {
+      extractor.addChunk('letters-A')
+      expect.assertions(1)
+      return extractor.getInlineStyleTags({ nonce: 'testnonce' }).then(data =>
+        expect(data).toMatchInlineSnapshot(`
+"<style type=\\"text/css\\" data-chunk=\\"letters-A\\" nonce=\\"testnonce\\">
+body {
+  background: pink;
+}
+
+</style>
+<style type=\\"text/css\\" data-chunk=\\"main\\" nonce=\\"testnonce\\">
 h1 {
   color: cyan;
 }
@@ -206,6 +235,27 @@ Array [
   <link
     data-chunk="main"
     href="/dist/node/main.css"
+    rel="stylesheet"
+  />,
+]
+`)
+    })
+
+    it('should add extraProps if specified', () => {
+      extractor.addChunk('letters-A')
+      expect(extractor.getStyleElements({ nonce: 'testnonce' }))
+        .toMatchInlineSnapshot(`
+Array [
+  <link
+    data-chunk="letters-A"
+    href="/dist/node/letters-A.css"
+    nonce="testnonce"
+    rel="stylesheet"
+  />,
+  <link
+    data-chunk="main"
+    href="/dist/node/main.css"
+    nonce="testnonce"
     rel="stylesheet"
   />,
 ]

--- a/packages/server/src/ChunkExtractor.test.js
+++ b/packages/server/src/ChunkExtractor.test.js
@@ -56,6 +56,16 @@ describe('ChunkExtrator', () => {
 <script async data-chunk=\\"main\\" src=\\"/dist/node/main.js\\"></script>"
 `)
     })
+
+    it('should add extra props if specified', () => {
+      extractor.addChunk('letters-A')
+      expect(extractor.getScriptTags({ nonce: 'testnonce' }))
+        .toMatchInlineSnapshot(`
+"<script nonce=\\"testnonce\\">window.__LOADABLE_REQUIRED_CHUNKS__ = [\\"letters-A\\"];</script>
+<script async data-chunk=\\"letters-A\\" src=\\"/dist/node/letters-A.js\\" nonce=\\"testnonce\\"></script>
+<script async data-chunk=\\"main\\" src=\\"/dist/node/main.js\\" nonce=\\"testnonce\\"></script>"
+`)
+    })
   })
 
   describe('#getScriptElements', () => {


### PR DESCRIPTION
## Summary

When you using loadable components server side
I want to be able to provide extra attributes to generated script tags, especially a `nonce` attribute used for `Content-Security-Policy`.


## Test plan

I added a small test on how you can use this new extraProps.
