### PR TITLE
fix: Add extra props option for links

### DIFF
--- a/packages/server/src/ChunkExtractor.js
+++ b/packages/server/src/ChunkExtractor.js
@@ -21,7 +21,10 @@ function getAssets(chunks, getAsset) {
 }
 
 function extraPropsToString(extraProps) {
-  return Object.keys(extraProps).reduce((acc, key) => `${acc} ${key}="${extraProps[key]}"`, '');
+  return Object.keys(extraProps).reduce(
+    (acc, key) => `${acc} ${key}="${extraProps[key]}"`,
+    '',
+  )
 }
 
 function assetToScriptTag(asset, extraProps) {
@@ -32,7 +35,13 @@ function assetToScriptTag(asset, extraProps) {
 
 function assetToScriptElement(asset, extraProps) {
   return (
-    <script key={asset.url} async data-chunk={asset.chunk} src={asset.url} {...extraProps} />
+    <script
+      key={asset.url}
+      async
+      data-chunk={asset.chunk}
+      src={asset.url}
+      {...extraProps}
+    />
   )
 }
 
@@ -62,7 +71,9 @@ function assetToStyleTagInline(asset, extraProps) {
         return
       }
       resolve(
-        `<style type="text/css" data-chunk="${asset.chunk}"${extraPropsToString(extraProps)}>
+        `<style type="text/css" data-chunk="${asset.chunk}"${extraPropsToString(
+          extraProps,
+        )}>
 ${data}
 </style>`,
       )
@@ -106,14 +117,14 @@ const LINK_ASSET_HINTS = {
   childAsset: 'data-parent-chunk',
 }
 
-function assetToLinkTag(asset) {
+function assetToLinkTag(asset, extraProps) {
   const hint = LINK_ASSET_HINTS[asset.type]
   return `<link ${hint}="${asset.chunk}" rel="${asset.linkType}" as="${
     asset.scriptType
-  }" href="${asset.url}">`
+  }" href="${asset.url}"${extraPropsToString(extraProps)}>`
 }
 
-function assetToLinkElement(asset) {
+function assetToLinkElement(asset, extraProps) {
   const hint = LINK_ASSET_HINTS[asset.type]
   const props = {
     key: asset.url,
@@ -121,6 +132,7 @@ function assetToLinkElement(asset) {
     rel: asset.linkType,
     as: asset.scriptType,
     href: asset.url,
+    ...extraProps,
   }
   return <link {...props} />
 }
@@ -232,7 +244,9 @@ class ChunkExtractor {
   }
 
   getRequiredChunksScriptTag(extraProps) {
-    return `<script${extraPropsToString(extraProps)}>${this.getRequiredChunksScriptContent()}</script>`
+    return `<script${extraPropsToString(
+      extraProps,
+    )}>${this.getRequiredChunksScriptContent()}</script>`
   }
 
   getRequiredChunksScriptElement(extraProps) {
@@ -285,12 +299,16 @@ class ChunkExtractor {
   getScriptTags(extraProps = {}) {
     const requiredScriptTag = this.getRequiredChunksScriptTag(extraProps)
     const mainAssets = this.getMainAssets('script')
-    const assetsScriptTags = mainAssets.map(asset => assetToScriptTag(asset, extraProps))
+    const assetsScriptTags = mainAssets.map(asset =>
+      assetToScriptTag(asset, extraProps),
+    )
     return joinTags([requiredScriptTag, ...assetsScriptTags])
   }
 
   getScriptElements(extraProps = {}) {
-    const requiredScriptElement = this.getRequiredChunksScriptElement(extraProps)
+    const requiredScriptElement = this.getRequiredChunksScriptElement(
+      extraProps,
+    )
     const mainAssets = this.getMainAssets('script')
     const assetsScriptElements = mainAssets.map(asset =>
       assetToScriptElement(asset, extraProps),
@@ -342,15 +360,15 @@ class ChunkExtractor {
     return [...mainAssets, ...preloadAssets, ...prefetchAssets]
   }
 
-  getLinkTags() {
+  getLinkTags(extraProps = {}) {
     const assets = this.getPreAssets()
-    const linkTags = assets.map(asset => assetToLinkTag(asset))
+    const linkTags = assets.map(asset => assetToLinkTag(asset, extraProps))
     return joinTags(linkTags)
   }
 
-  getLinkElements() {
+  getLinkElements(extraProps = {}) {
     const assets = this.getPreAssets()
-    return assets.map(asset => assetToLinkElement(asset))
+    return assets.map(asset => assetToLinkElement(asset, extraProps))
   }
 }
 

--- a/packages/server/src/ChunkExtractor.test.js
+++ b/packages/server/src/ChunkExtractor.test.js
@@ -336,6 +336,19 @@ h1 {
 <link data-parent-chunk=\\"main\\" rel=\\"prefetch\\" as=\\"script\\" href=\\"/dist/node/letters-D.js\\">"
 `)
     })
+
+    it('should add extraProps if specified', () => {
+      extractor.addChunk('letters-A')
+      expect(extractor.getLinkTags({ nonce: 'testnonce' }))
+        .toMatchInlineSnapshot(`
+"<link data-chunk=\\"letters-A\\" rel=\\"preload\\" as=\\"style\\" href=\\"/dist/node/letters-A.css\\" nonce=\\"testnonce\\">
+<link data-chunk=\\"letters-A\\" rel=\\"preload\\" as=\\"script\\" href=\\"/dist/node/letters-A.js\\" nonce=\\"testnonce\\">
+<link data-chunk=\\"main\\" rel=\\"preload\\" as=\\"style\\" href=\\"/dist/node/main.css\\" nonce=\\"testnonce\\">
+<link data-chunk=\\"main\\" rel=\\"preload\\" as=\\"script\\" href=\\"/dist/node/main.js\\" nonce=\\"testnonce\\">
+<link data-parent-chunk=\\"main\\" rel=\\"preload\\" as=\\"script\\" href=\\"/dist/node/letters-C.js\\" nonce=\\"testnonce\\">
+<link data-parent-chunk=\\"main\\" rel=\\"prefetch\\" as=\\"script\\" href=\\"/dist/node/letters-D.js\\" nonce=\\"testnonce\\">"
+`)
+    })
   })
 
   describe('#getLinkElements', () => {
@@ -408,6 +421,57 @@ Array [
     as="script"
     data-parent-chunk="main"
     href="/dist/node/letters-D.js"
+    rel="prefetch"
+  />,
+]
+`)
+    })
+
+    it('should add extraProps if specified', () => {
+      extractor.addChunk('letters-A')
+      expect(extractor.getLinkElements({ nonce: 'testnonce' }))
+        .toMatchInlineSnapshot(`
+Array [
+  <link
+    as="style"
+    data-chunk="letters-A"
+    href="/dist/node/letters-A.css"
+    nonce="testnonce"
+    rel="preload"
+  />,
+  <link
+    as="script"
+    data-chunk="letters-A"
+    href="/dist/node/letters-A.js"
+    nonce="testnonce"
+    rel="preload"
+  />,
+  <link
+    as="style"
+    data-chunk="main"
+    href="/dist/node/main.css"
+    nonce="testnonce"
+    rel="preload"
+  />,
+  <link
+    as="script"
+    data-chunk="main"
+    href="/dist/node/main.js"
+    nonce="testnonce"
+    rel="preload"
+  />,
+  <link
+    as="script"
+    data-parent-chunk="main"
+    href="/dist/node/letters-C.js"
+    nonce="testnonce"
+    rel="preload"
+  />,
+  <link
+    as="script"
+    data-parent-chunk="main"
+    href="/dist/node/letters-D.js"
+    nonce="testnonce"
     rel="prefetch"
   />,
 ]


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary
Add extra prop options for `getLinkTags` and `getLinkElements`.

The latest version added extra prop options for all the get tag functions. It seems as though links were missed in this even though they were documented as having the option.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

Added snapshot tests for the new options. 

Note: I ran prettier over the project but it seemed to change some extra lines. Not sure if it was upto date previously. 

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
