### PR TITLE
feat(babel-plugin): transform code annotated with magic comment

### DIFF
--- a/packages/babel-plugin/src/__snapshots__/index.test.js.snap
+++ b/packages/babel-plugin/src/__snapshots__/index.test.js.snap
@@ -1,5 +1,85 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`plugin Magic comment should transpile object properties 1`] = `
+"export default {
+  loader: () => import(
+  /* webpackChunkName: \\"moment\\" */
+  {
+    chunkName() {
+      return \\"moment\\";
+    },
+
+    isReady(props) {
+      if (typeof __webpack_modules__ !== 'undefined') {
+        return !!__webpack_modules__[this.resolve(props)];
+      }
+
+      return false;
+    },
+
+    requireAsync: 'moment',
+
+    requireSync(props) {
+      const id = this.resolve(props);
+
+      if (typeof __webpack_require__ !== 'undefined') {
+        return __webpack_require__(id);
+      }
+
+      return eval('module.require')(id);
+    },
+
+    resolve() {
+      if (require.resolveWeak) {
+        return require.resolveWeak(\\"moment\\");
+      }
+
+      return require('path').resolve(__dirname, \\"moment\\");
+    }
+
+  })
+};"
+`;
+
+exports[`plugin Magic comment should transpile variable decalrations 1`] = `
+"const loader = () => import(
+/* webpackChunkName: \\"moment\\" */
+{
+  chunkName() {
+    return \\"moment\\";
+  },
+
+  isReady(props) {
+    if (typeof __webpack_modules__ !== 'undefined') {
+      return !!__webpack_modules__[this.resolve(props)];
+    }
+
+    return false;
+  },
+
+  requireAsync: 'moment',
+
+  requireSync(props) {
+    const id = this.resolve(props);
+
+    if (typeof __webpack_require__ !== 'undefined') {
+      return __webpack_require__(id);
+    }
+
+    return eval('module.require')(id);
+  },
+
+  resolve() {
+    if (require.resolveWeak) {
+      return require.resolveWeak(\\"moment\\");
+    }
+
+    return require('path').resolve(__dirname, \\"moment\\");
+  }
+
+});"
+`;
+
 exports[`plugin aggressive import should work with destructuration 1`] = `
 "loadable({
   chunkName({

--- a/packages/babel-plugin/src/index.test.js
+++ b/packages/babel-plugin/src/index.test.js
@@ -122,4 +122,26 @@ describe('plugin', () => {
       expect(result).toMatchSnapshot()
     })
   })
+
+  describe('Magic comment', () => {
+    it('should transpile variable decalrations', () => {
+      const result = testPlugin(`
+      /* #__LOADABLE__ */
+      const loader = () => import('moment');
+    `)
+
+      expect(result).toMatchSnapshot()
+    })
+
+    it('should transpile object properties', () => {
+      const result = testPlugin(`
+      export default {
+        /* #__LOADABLE__ */
+        loader: () => import('moment')
+      }
+    `)
+
+      expect(result).toMatchSnapshot()
+    })
+  })
 })


### PR DESCRIPTION
## Summary

This PR updates the babel plugin to also transform the imports inside code annotated with the `/* #__LOADABLE__ */` comment as specified in https://github.com/smooth-code/loadable-components/issues/192.

Right now the plugin is able to transform these 2 cases:

```JS
/* #__LOADABLE__ */
const loader = () => import('moment');
```

```JS
export default {
  /* #__LOADABLE__ */
  loader: () => import('moment')
}
```

Should it also consider any other case?

This is the first time I work on a babel plugin, so there may be some things to be improved in my code.

Docs should also be updated, but I'm not quite sure where it would be the best place to include this new functionality.

## Test plan

I added a few test cases for the new code and snapshots seem to be ok (compared with the other test cases).

Thanks!
