### PR TITLE
Allow query-param cache busting in chunk names

### DIFF
--- a/packages/server/__fixtures__/stats.json
+++ b/packages/server/__fixtures__/stats.json
@@ -13,6 +13,10 @@
     "letters-B": "letters-B.js",
     "letters-C": "letters-C.js",
     "letters-D": "letters-D.js",
+    "letters-E": [
+      "letters-E.css?param",
+      "letters-E.js?param"
+    ],
     "main": [
       "main.css",
       "main.js"
@@ -67,6 +71,26 @@
       ],
       "chunkNames": [
         "letters-D"
+      ]
+    },
+    {
+      "name": "letters-E.css?param",
+      "size": 517,
+      "chunks": [
+        "letters-E"
+      ],
+      "chunkNames": [
+        "letters-E"
+      ]
+    },
+    {
+      "name": "letters-E.js?param",
+      "size": 517,
+      "chunks": [
+        "letters-E"
+      ],
+      "chunkNames": [
+        "letters-E"
       ]
     },
     {
@@ -215,6 +239,17 @@
       ],
       "assets": [
         "letters-D.js"
+      ],
+      "children": {},
+      "childAssets": {}
+    },
+    "letters-E": {
+      "chunks": [
+        "letters-E"
+      ],
+      "assets": [
+        "letters-E.css?param",
+        "letters-E.js?param"
       ],
       "children": {},
       "childAssets": {}

--- a/packages/server/src/ChunkExtractor.js
+++ b/packages/server/src/ChunkExtractor.js
@@ -170,7 +170,7 @@ class ChunkExtractor {
   createChunkAsset({ filename, chunk, type, linkType }) {
     return {
       filename,
-      scriptType: extensionToScriptType(path.extname(filename).toLowerCase()),
+      scriptType: extensionToScriptType(path.extname(filename).split('?')[0].toLowerCase()),
       chunk,
       url: this.resolvePublicUrl(filename),
       path: path.join(this.outputPath, filename),

--- a/packages/server/src/ChunkExtractor.test.js
+++ b/packages/server/src/ChunkExtractor.test.js
@@ -57,6 +57,15 @@ describe('ChunkExtrator', () => {
 `)
     })
 
+    it('should allow for query params in chunk names', () => {
+      extractor.addChunk('letters-E')
+      expect(extractor.getScriptTags()).toMatchInlineSnapshot(`
+"<script>window.__LOADABLE_REQUIRED_CHUNKS__ = [\\"letters-E\\"];</script>
+<script async data-chunk=\\"letters-E\\" src=\\"/dist/node/letters-E.js?param\\"></script>
+<script async data-chunk=\\"main\\" src=\\"/dist/node/main.js\\"></script>"
+`)
+    })
+
     it('should add extra props if specified', () => {
       extractor.addChunk('letters-A')
       expect(extractor.getScriptTags({ nonce: 'testnonce' }))
@@ -113,6 +122,31 @@ Array [
 `)
     })
 
+    it('should allow for query params in chunk names', () => {
+      extractor.addChunk('letters-E')
+      expect(extractor.getScriptElements()).toMatchInlineSnapshot(`
+Array [
+  <script
+    dangerouslySetInnerHTML={
+      Object {
+        "__html": "window.__LOADABLE_REQUIRED_CHUNKS__ = [\\"letters-E\\"];",
+      }
+    }
+  />,
+  <script
+    async={true}
+    data-chunk="letters-E"
+    src="/dist/node/letters-E.js?param"
+  />,
+  <script
+    async={true}
+    data-chunk="main"
+    src="/dist/node/main.js"
+  />,
+]
+`)
+    })
+
     it('should add extra props if specified', () => {
       extractor.addChunk('letters-A')
       expect(extractor.getScriptElements({ nonce: 'testnonce' }))
@@ -154,6 +188,14 @@ Array [
       extractor.addChunk('letters-A')
       expect(extractor.getStyleTags()).toMatchInlineSnapshot(`
 "<link data-chunk=\\"letters-A\\" rel=\\"stylesheet\\" href=\\"/dist/node/letters-A.css\\">
+<link data-chunk=\\"main\\" rel=\\"stylesheet\\" href=\\"/dist/node/main.css\\">"
+`)
+    })
+
+    it('should allow for query params in chunk names', () => {
+      extractor.addChunk('letters-E')
+      expect(extractor.getStyleTags()).toMatchInlineSnapshot(`
+"<link data-chunk=\\"letters-E\\" rel=\\"stylesheet\\" href=\\"/dist/node/letters-E.css?param\\">
 <link data-chunk=\\"main\\" rel=\\"stylesheet\\" href=\\"/dist/node/main.css\\">"
 `)
     })
@@ -230,6 +272,24 @@ Array [
   <link
     data-chunk="letters-A"
     href="/dist/node/letters-A.css"
+    rel="stylesheet"
+  />,
+  <link
+    data-chunk="main"
+    href="/dist/node/main.css"
+    rel="stylesheet"
+  />,
+]
+`)
+    })
+
+    it('should allow for query params in chunk names', () => {
+      extractor.addChunk('letters-E')
+      expect(extractor.getStyleElements()).toMatchInlineSnapshot(`
+Array [
+  <link
+    data-chunk="letters-E"
+    href="/dist/node/letters-E.css?param"
     rel="stylesheet"
   />,
   <link
@@ -337,6 +397,18 @@ h1 {
 `)
     })
 
+    it('should allow for query params in chunk names', () => {
+      extractor.addChunk('letters-E')
+      expect(extractor.getLinkTags()).toMatchInlineSnapshot(`
+"<link data-chunk=\\"letters-E\\" rel=\\"preload\\" as=\\"style\\" href=\\"/dist/node/letters-E.css?param\\">
+<link data-chunk=\\"letters-E\\" rel=\\"preload\\" as=\\"script\\" href=\\"/dist/node/letters-E.js?param\\">
+<link data-chunk=\\"main\\" rel=\\"preload\\" as=\\"style\\" href=\\"/dist/node/main.css\\">
+<link data-chunk=\\"main\\" rel=\\"preload\\" as=\\"script\\" href=\\"/dist/node/main.js\\">
+<link data-parent-chunk=\\"main\\" rel=\\"preload\\" as=\\"script\\" href=\\"/dist/node/letters-C.js\\">
+<link data-parent-chunk=\\"main\\" rel=\\"prefetch\\" as=\\"script\\" href=\\"/dist/node/letters-D.js\\">"
+`)
+    })
+
     it('should add extraProps if specified', () => {
       extractor.addChunk('letters-A')
       expect(extractor.getLinkTags({ nonce: 'testnonce' }))
@@ -397,6 +469,50 @@ Array [
     as="script"
     data-chunk="letters-A"
     href="/dist/node/letters-A.js"
+    rel="preload"
+  />,
+  <link
+    as="style"
+    data-chunk="main"
+    href="/dist/node/main.css"
+    rel="preload"
+  />,
+  <link
+    as="script"
+    data-chunk="main"
+    href="/dist/node/main.js"
+    rel="preload"
+  />,
+  <link
+    as="script"
+    data-parent-chunk="main"
+    href="/dist/node/letters-C.js"
+    rel="preload"
+  />,
+  <link
+    as="script"
+    data-parent-chunk="main"
+    href="/dist/node/letters-D.js"
+    rel="prefetch"
+  />,
+]
+`)
+    })
+
+    it('should allow for query params in chunk names', () => {
+      extractor.addChunk('letters-E')
+      expect(extractor.getLinkElements()).toMatchInlineSnapshot(`
+Array [
+  <link
+    as="style"
+    data-chunk="letters-E"
+    href="/dist/node/letters-E.css?param"
+    rel="preload"
+  />,
+  <link
+    as="script"
+    data-chunk="letters-E"
+    href="/dist/node/letters-E.js?param"
     rel="preload"
   />,
   <link


### PR DESCRIPTION
We use query params for cache-busting (eg, `chunkFilename: '[name].js?[chunkhash]'`), but `extname()` can't properly get the extension when there's a param attached. This change would allow the use of query params.