### PR TITLE
Update docs to correct syntax for prefetching example

### DIFF
--- a/website/src/pages/docs/prefetching.mdx
+++ b/website/src/pages/docs/prefetching.mdx
@@ -29,7 +29,7 @@ It can be useful to trigger a `preload` on mouse over:
 ```js
 import loadable from '@loadable/component'
 
-const Infos = loadable(() => './Infos')
+const Infos = loadable(() => import('./Infos'))
 
 function App() {
   const [show, setShow] = useState(false)

--- a/website/src/pages/docs/prefetching.mdx
+++ b/website/src/pages/docs/prefetching.mdx
@@ -29,7 +29,7 @@ It can be useful to trigger a `preload` on mouse over:
 ```js
 import loadable from '@loadable/component'
 
-const Infos = () => loadable(() => './Infos')
+const Infos = loadable(() => './Infos')
 
 function App() {
   const [show, setShow] = useState(false)


### PR DESCRIPTION
I think the docs are incorrect, the extra arrow function is not necessary and it's missing `import`.