### PR TITLE
Adding basic support for .mjs file format.

### DIFF
--- a/packages/server/src/ChunkExtractor.js
+++ b/packages/server/src/ChunkExtractor.js
@@ -9,6 +9,7 @@ import { smartRequire, joinURLPath } from './util'
 
 const EXTENSION_SCRIPT_TYPES = {
   '.js': 'script',
+  '.mjs': 'script',
   '.css': 'style',
 }
 


### PR DESCRIPTION
As almost all major browsers already implemented es6 modules and pushing .mjs file format for the es6 modules to keep it consistent with nodejs environment. 
High performance website are considering to send different code to modern and legacy browsers.

This pull request will only help getting script tags with correct filename for both .js and .mjs.

An approach for sending defferential code will look something like.

```
var legacyExtractor = new ChunkExtractor({ statsFile: legacyStatsFile })
var modernExtractor = new ChunkExtractor({ statsFile: modernStatsFile })
// cache will call the function only once.
let tags = await cache(req.url, () => {
                let legacyJSX = legacyExtractor.collectChunks(<App />);
                let modernJSX = modernExtractor.collectChunks(<App />);
                ReactDOMServer.renderToString(legacyJSX);
                ReactDOMServer.renderToString(modernJSX);
                return {
                    legacyTags: legacyExtractor.getScriptTags(),
                    modernTags: modernExtractor.getScriptTags()
                }
            });
let bodyStream = ReactDOMServer.renderToNodeStream(<App />);
            bodyStream.pipe(res, {end: false});
            bodyStream.on('end', () => {
                res.end(`</div>${
                        tags.legacyTags
                        .replace(/<script/g,"<script nomodule")
                    }${
                        tags.modernTags
                        .replace(/<script/g,'<script type="module"')
                    }
                </body></html>`);
            });
```
It will be much better in next version if lodable-component itself will return script tags with type="modules" and nomodules.