### PR TITLE
Warn against having comments=false in babel

### DIFF
--- a/website/src/pages/docs/babel-plugin.mdx
+++ b/website/src/pages/docs/babel-plugin.mdx
@@ -79,6 +79,8 @@ As you can see the "webpackChunkName" annotation is automatically added.
 
 On client side, the two code are completely compatible.
 
+Please note that babel must not be configured [to strip comments](https://babeljs.io/docs/en/options#comments), since the chunk name is defined in a comment.
+
 ## Loadable detection
 
 The detection of a loadable component is based on the keyword "loadable". It is an opiniated choice, it gives you flexibility but it could also be restrictive.


### PR DESCRIPTION


<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

It took me an hour+ to figure out why I wasn't getting chunk names in my stats file... turns out babel was stripping the comments injected by this plugin. It isn't immediately obvious how the plugin works, so I figured I'd save the next person some time and make a note here.

## Test plan

Nothing; it's just a documentation change.
