### PR TITLE
Adding Named Exports support for SSR

### DIFF
--- a/packages/component/src/createLoadable.js
+++ b/packages/component/src/createLoadable.js
@@ -20,8 +20,22 @@ const withChunkExtractor = Component => props => (
 const identity = v => v
 
 function createLoadable({ resolve = identity, render, onLoad }) {
-  function loadable(loadableConstructor, options = {}) {
+  function loadable(loadableConstructor, ...additionalArguments) {
     const ctor = resolveConstructor(loadableConstructor)
+    let componentName
+    let options = {}
+
+    if (additionalArguments.length) {
+      if (additionalArguments.length === 2) {
+        [componentName, options] = additionalArguments
+      } else if (additionalArguments.length === 1) {
+        if (typeof additionalArguments[0] === 'string') {
+          [componentName] = additionalArguments
+        } else if (typeof additionalArguments[0] === 'object') {
+          [options] = additionalArguments
+        }
+      }
+    }
 
     class InnerLoadable extends React.Component {
       constructor(props) {
@@ -97,7 +111,7 @@ function createLoadable({ resolve = identity, render, onLoad }) {
         try {
           const loadedModule = ctor.requireSync(this.props)
           const result = resolve(loadedModule, { Loadable })
-          this.state.result = options.named ? result[options.named] : result
+          this.state.result = componentName ? result[componentName] : result
           this.state.loading = false
         } catch (error) {
           this.state.error = error

--- a/packages/component/src/createLoadable.js
+++ b/packages/component/src/createLoadable.js
@@ -26,7 +26,7 @@ function createLoadable({ resolve = identity, render, onLoad }) {
 
     if (typeof additionalArguments[0] === "object") {
       componentName = undefined;
-      options = additionalArguments[0];
+      [options] = additionalArguments;
     }
 
     class InnerLoadable extends React.Component {

--- a/packages/component/src/createLoadable.js
+++ b/packages/component/src/createLoadable.js
@@ -22,19 +22,11 @@ const identity = v => v
 function createLoadable({ resolve = identity, render, onLoad }) {
   function loadable(loadableConstructor, ...additionalArguments) {
     const ctor = resolveConstructor(loadableConstructor)
-    let componentName
-    let options = {}
+    let [componentName, options = {}] = additionalArguments;
 
-    if (additionalArguments.length) {
-      if (additionalArguments.length === 2) {
-        [componentName, options] = additionalArguments
-      } else if (additionalArguments.length === 1) {
-        if (typeof additionalArguments[0] === 'string') {
-          [componentName] = additionalArguments
-        } else if (typeof additionalArguments[0] === 'object') {
-          [options] = additionalArguments
-        }
-      }
+    if (typeof additionalArguments[0] === "object") {
+      componentName = undefined;
+      options = additionalArguments[0];
     }
 
     class InnerLoadable extends React.Component {

--- a/packages/component/src/createLoadable.js
+++ b/packages/component/src/createLoadable.js
@@ -97,7 +97,7 @@ function createLoadable({ resolve = identity, render, onLoad }) {
         try {
           const loadedModule = ctor.requireSync(this.props)
           const result = resolve(loadedModule, { Loadable })
-          this.state.result = result
+          this.state.result = options.named ? result[options.named] : result
           this.state.loading = false
         } catch (error) {
           this.state.error = error

--- a/website/src/pages/docs/server-side-rendering.mdx
+++ b/website/src/pages/docs/server-side-rendering.mdx
@@ -188,9 +188,7 @@ export const OtherComponent = () => 'Other Component'
 **App.js**
 
 ```js
-const OtherComponent = loadable(() => import('./OtherComponent'), {
-  named: 'OtherComponent',
-})
+const OtherComponent = loadable(() => import('./OtherComponent'), 'OtherComponent', { /* options */ })
 
 function MyComponent() {
   return (

--- a/website/src/pages/docs/server-side-rendering.mdx
+++ b/website/src/pages/docs/server-side-rendering.mdx
@@ -175,6 +175,32 @@ const html = `<html>
 
 > It only works with `renderToString` API. Since `<link>` must be added in the `<head>`, you can't do it using `renderToNodeStream`.
 
+## Named Exports
+
+You can specify a `named` export in `loadable` options:
+
+**OtherComponent.js**
+
+```js
+export const OtherComponent = () => 'Other Component'
+```
+
+**App.js**
+
+```js
+const OtherComponent = loadable(() => import('./OtherComponent'), {
+  named: 'OtherComponent',
+})
+
+function MyComponent() {
+  return (
+    <div>
+      <OtherComponent />
+    </div>
+  )
+}
+```
+
 ## CSS
 
 Extracted CSS using plugins like ["mini-css-extract-plugin"](https://github.com/webpack-contrib/mini-css-extract-plugin) are automatically collected, you can get them using `getStyleTags` or `getStyleElements`.


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

Fixes #245 

Problem arose while trying to import named exports server side. Method described in #97 didn't work (I suspect because `renderToString` doesn't support `async/await`) so this seemed like the ideal solution.

## Test plan

**OtherComponent.js**

```js
export const OtherComponent = () => 'Other Component'
```

**App.js**

```js
const OtherComponent = loadable(() => import('./OtherComponent'), 'OtherComponent')

function MyComponent() {
  return (
    <div>
      <OtherComponent />
    </div>
  )
}
```
