### PR TITLE
fix(docs): fix minor typo in documentation for code-splitting

### DIFF
--- a/website/src/pages/docs/code-splitting.mdx
+++ b/website/src/pages/docs/code-splitting.mdx
@@ -47,7 +47,7 @@ When using Babel, you’ll need to make sure that Babel can parse the dynamic im
 
 React supports code splitting out of the box with [`React.lazy`](https://reactjs.org/docs/code-splitting.html#reactlazy). However it has [some limitations](/docs/loadable-vs-react-lazy), this is why `@loadable/component` exists.
 
-In a React application, most of the time you want to split your components. Splitting a component implies to be able to wait for this component to be loaded (showing a fallack during loading) but also to handle errors.
+In a React application, most of the time you want to split your components. Splitting a component implies to be able to wait for this component to be loaded (showing a fallback during loading) but also to handle errors.
 
 **Example of component splitting:**
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

- Fix minor typo in code-splitting documentation on website

## Test plan

N/A