### PR TITLE
docs: fix broken link

### DIFF
--- a/website/src/pages/docs/loadable-vs-react-lazy.mdx
+++ b/website/src/pages/docs/loadable-vs-react-lazy.mdx
@@ -29,7 +29,7 @@ Suspense is supported by `React.lazy` and by `@loadable/component`. `@loadable/c
 
 Suspense is not available server-side and `React.lazy` can only works with Suspense. That's why today, `React.lazy` is not an option if you need Server Side Rendering.
 
-`@loadable/component` provides a complete solution to make [Server Side Rendering](/docs/server-side-rendering) possible.
+`@loadable/component` provides a complete solution to make [Server Side Rendering](/docs/server-side-rendering/) possible.
 
 ## Library splitting
 


### PR DESCRIPTION
## Summary

The link to the SSR page from the [Comparison with React.lazy](https://www.smooth-code.com/open-source/loadable-components/docs/loadable-vs-react-lazy/) page is broken as it's missing a trailing slash and ends up taking users to the 404 page. 

## Test plan

* [Broken URL](https://www.smooth-code.com/open-source/loadable-components/docs/server-side-rendering)
* [Fixed URL](https://www.smooth-code.com/open-source/loadable-components/docs/server-side-rendering/)
