### PR TITLE
fix(webpack-plugin): create output folder with mkdirp

### DIFF
--- a/packages/webpack-plugin/package.json
+++ b/packages/webpack-plugin/package.json
@@ -22,5 +22,8 @@
   },
   "peerDependencies": {
     "webpack": ">=4.6.0"
+  },
+  "dependencies": {
+    "mkdirp": "^0.5.1"
   }
 }

--- a/packages/webpack-plugin/src/index.js
+++ b/packages/webpack-plugin/src/index.js
@@ -1,5 +1,6 @@
 const nodePath = require('path')
 const fs = require('fs')
+const mkdirp = require('mkdirp')
 
 class LoadablePlugin {
   constructor({
@@ -57,7 +58,7 @@ class LoadablePlugin {
 
     try {
       if (!fs.existsSync(outputFolder)) {
-        fs.mkdirSync(outputFolder)
+        mkdirp.sync(outputFolder)
       }
     } catch (err) {
       if (err.code !== 'EEXIST') {


### PR DESCRIPTION
## Summary

If neither `outputFolder` nor the directory of `outputFolder` exist, then `outputFolder` would not be available for write. For example, if `outputFolder` is `/a/b/c`, but `/a/b` does not exist, then the plugin cannot create directory `/a/b/c` and cannot write any files to it.

## Test plan

I tested the razzle example in the repo with the following steps:
1. in `examples/razzle/razzle.config.js`, change `const filename = path.resolve(__dirname, 'build')` to `const filename = path.resolve(__dirname, 'build/a/b/c')`
2. run `yarn start` and observe that it results in an error `Error: ENOENT: no such file or directory, mkdir ...`
3. use the patched plugin and try `yarn start` again, observe that there is no error this time, the folder `build/a/b/c` is created, and `loadable-stats.json` is written to `build/a/b/c`
