### PR TITLE
implement attribute function

### DIFF
--- a/packages/server/src/ChunkExtractor.js
+++ b/packages/server/src/ChunkExtractor.js
@@ -20,9 +20,13 @@ function getAssets(chunks, getAsset) {
   return _.uniqBy(_.flatMap(chunks, chunk => getAsset(chunk)), 'url')
 }
 
-function extraPropsToString(extraProps) {
-  return Object.keys(extraProps).reduce(
-    (acc, key) => `${acc} ${key}="${extraProps[key]}"`,
+function handleExtraProps(asset, extraProps) {
+  return typeof extraProps === 'function' ? extraProps(asset) : extraProps
+}
+
+function extraPropsToString(asset, extraProps) {
+  return Object.entries(handleExtraProps(asset, extraProps)).reduce(
+    (acc, [key, value]) => `${acc} ${key}="${value}"`,
     '',
   )
 }
@@ -30,7 +34,7 @@ function extraPropsToString(extraProps) {
 function assetToScriptTag(asset, extraProps) {
   return `<script async data-chunk="${asset.chunk}" src="${
     asset.url
-  }"${extraPropsToString(extraProps)}></script>`
+  }"${extraPropsToString(asset, extraProps)}></script>`
 }
 
 function assetToScriptElement(asset, extraProps) {
@@ -40,7 +44,7 @@ function assetToScriptElement(asset, extraProps) {
       async
       data-chunk={asset.chunk}
       src={asset.url}
-      {...extraProps}
+      {...handleExtraProps(asset, extraProps)}
     />
   )
 }
@@ -60,7 +64,7 @@ function assetToStyleString(asset) {
 function assetToStyleTag(asset, extraProps) {
   return `<link data-chunk="${asset.chunk}" rel="stylesheet" href="${
     asset.url
-  }"${extraPropsToString(extraProps)}>`
+  }"${extraPropsToString(asset, extraProps)}>`
 }
 
 function assetToStyleTagInline(asset, extraProps) {
@@ -72,6 +76,7 @@ function assetToStyleTagInline(asset, extraProps) {
       }
       resolve(
         `<style type="text/css" data-chunk="${asset.chunk}"${extraPropsToString(
+          asset,
           extraProps,
         )}>
 ${data}
@@ -88,7 +93,7 @@ function assetToStyleElement(asset, extraProps) {
       data-chunk={asset.chunk}
       rel="stylesheet"
       href={asset.url}
-      {...extraProps}
+      {...handleExtraProps(asset, extraProps)}
     />
   )
 }
@@ -105,7 +110,7 @@ function assetToStyleElementInline(asset, extraProps) {
           key={asset.url}
           data-chunk={asset.chunk}
           dangerouslySetInnerHTML={{ __html: data }}
-          {...extraProps}
+          {...handleExtraProps(asset, extraProps)}
         />,
       )
     })
@@ -121,7 +126,7 @@ function assetToLinkTag(asset, extraProps) {
   const hint = LINK_ASSET_HINTS[asset.type]
   return `<link ${hint}="${asset.chunk}" rel="${asset.linkType}" as="${
     asset.scriptType
-  }" href="${asset.url}"${extraPropsToString(extraProps)}>`
+  }" href="${asset.url}"${extraPropsToString(asset, extraProps)}>`
 }
 
 function assetToLinkElement(asset, extraProps) {
@@ -132,7 +137,7 @@ function assetToLinkElement(asset, extraProps) {
     rel: asset.linkType,
     as: asset.scriptType,
     href: asset.url,
-    ...extraProps,
+    ...handleExtraProps(asset, extraProps),
   }
   return <link {...props} />
 }
@@ -248,11 +253,12 @@ class ChunkExtractor {
 
   getRequiredChunksScriptTag(extraProps) {
     return `<script id="${LOADABLE_REQUIRED_CHUNKS_KEY}" type="application/json"${extraPropsToString(
+      null,
       extraProps,
     )}>${this.getRequiredChunksScriptContent()}</script>`
   }
 
-  getRequiredChunksScriptElement(extraProps) {
+  getRequiredChunksScriptElement(asset, extraProps) {
     return (
       <script
         key="required"
@@ -261,7 +267,7 @@ class ChunkExtractor {
         dangerouslySetInnerHTML={{
           __html: this.getRequiredChunksScriptContent(),
         }}
-        {...extraProps}
+        {...handleExtraProps(asset, extraProps)}
       />
     )
   }
@@ -312,6 +318,7 @@ class ChunkExtractor {
 
   getScriptElements(extraProps = {}) {
     const requiredScriptElement = this.getRequiredChunksScriptElement(
+      null,
       extraProps,
     )
     const mainAssets = this.getMainAssets('script')

--- a/packages/server/src/ChunkExtractor.js
+++ b/packages/server/src/ChunkExtractor.js
@@ -258,7 +258,7 @@ class ChunkExtractor {
     )}>${this.getRequiredChunksScriptContent()}</script>`
   }
 
-  getRequiredChunksScriptElement(asset, extraProps) {
+  getRequiredChunksScriptElement(extraProps) {
     return (
       <script
         key="required"
@@ -267,7 +267,7 @@ class ChunkExtractor {
         dangerouslySetInnerHTML={{
           __html: this.getRequiredChunksScriptContent(),
         }}
-        {...handleExtraProps(asset, extraProps)}
+        {...handleExtraProps(null, extraProps)}
       />
     )
   }
@@ -318,7 +318,6 @@ class ChunkExtractor {
 
   getScriptElements(extraProps = {}) {
     const requiredScriptElement = this.getRequiredChunksScriptElement(
-      null,
       extraProps,
     )
     const mainAssets = this.getMainAssets('script')

--- a/packages/server/src/ChunkExtractor.test.js
+++ b/packages/server/src/ChunkExtractor.test.js
@@ -66,13 +66,26 @@ describe('ChunkExtrator', () => {
 `)
     })
 
-    it('should add extra props if specified', () => {
+    it('should add extra props if specified - object argument', () => {
       extractor.addChunk('letters-A')
       expect(extractor.getScriptTags({ nonce: 'testnonce' }))
         .toMatchInlineSnapshot(`
 "<script id=\\"__LOADABLE_REQUIRED_CHUNKS__\\" type=\\"application/json\\" nonce=\\"testnonce\\">[\\"letters-A\\"]</script>
 <script async data-chunk=\\"main\\" src=\\"/dist/node/main.js\\" nonce=\\"testnonce\\"></script>
 <script async data-chunk=\\"letters-A\\" src=\\"/dist/node/letters-A.js\\" nonce=\\"testnonce\\"></script>"
+`)
+    })
+
+    it('should add extra props if specified - function argument', () => {
+      extractor.addChunk('letters-A')
+      expect(
+        extractor.getScriptTags(asset => {
+          return { nonce: asset ? asset.chunk : 'anonymous' }
+        }),
+      ).toMatchInlineSnapshot(`
+"<script id=\\"__LOADABLE_REQUIRED_CHUNKS__\\" type=\\"application/json\\" nonce=\\"anonymous\\">[\\"letters-A\\"]</script>
+<script async data-chunk=\\"main\\" src=\\"/dist/node/main.js\\" nonce=\\"main\\"></script>
+<script async data-chunk=\\"letters-A\\" src=\\"/dist/node/letters-A.js\\" nonce=\\"letters-A\\"></script>"
 `)
     })
   })
@@ -153,7 +166,7 @@ Array [
 `)
     })
 
-    it('should add extra props if specified', () => {
+    it('should add extra props if specified - object argument', () => {
       extractor.addChunk('letters-A')
       expect(extractor.getScriptElements({ nonce: 'testnonce' }))
         .toMatchInlineSnapshot(`
@@ -178,6 +191,40 @@ Array [
     async={true}
     data-chunk="letters-A"
     nonce="testnonce"
+    src="/dist/node/letters-A.js"
+  />,
+]
+`)
+    })
+
+    it('should add extra props if specified - function argument', () => {
+      extractor.addChunk('letters-A')
+      expect(
+        extractor.getScriptElements(asset => {
+          return { nonce: asset ? asset.chunk : 'anonymous' }
+        }),
+      ).toMatchInlineSnapshot(`
+Array [
+  <script
+    dangerouslySetInnerHTML={
+      Object {
+        "__html": "[\\"letters-A\\"]",
+      }
+    }
+    id="__LOADABLE_REQUIRED_CHUNKS__"
+    nonce="anonymous"
+    type="application/json"
+  />,
+  <script
+    async={true}
+    data-chunk="main"
+    nonce="main"
+    src="/dist/node/main.js"
+  />,
+  <script
+    async={true}
+    data-chunk="letters-A"
+    nonce="letters-A"
     src="/dist/node/letters-A.js"
   />,
 ]
@@ -208,12 +255,24 @@ Array [
 `)
     })
 
-    it('should add extraProps if specified', () => {
+    it('should add extraProps if specified - object argument', () => {
       extractor.addChunk('letters-A')
       expect(extractor.getStyleTags({ nonce: 'testnonce' }))
         .toMatchInlineSnapshot(`
 "<link data-chunk=\\"main\\" rel=\\"stylesheet\\" href=\\"/dist/node/main.css\\" nonce=\\"testnonce\\">
 <link data-chunk=\\"letters-A\\" rel=\\"stylesheet\\" href=\\"/dist/node/letters-A.css\\" nonce=\\"testnonce\\">"
+`)
+    })
+
+    it('should add extraProps if specified - function argument', () => {
+      extractor.addChunk('letters-A')
+      expect(
+        extractor.getStyleTags(asset => ({
+          nonce: asset ? asset.chunk : 'anonymous',
+        })),
+      ).toMatchInlineSnapshot(`
+"<link data-chunk=\\"main\\" rel=\\"stylesheet\\" href=\\"/dist/node/main.css\\" nonce=\\"main\\">
+<link data-chunk=\\"letters-A\\" rel=\\"stylesheet\\" href=\\"/dist/node/letters-A.css\\" nonce=\\"letters-A\\">"
 `)
     })
   })
@@ -239,7 +298,7 @@ body {
       )
     })
 
-    it('should add extraProps if specified', () => {
+    it('should add extraProps if specified - object argument', () => {
       extractor.addChunk('letters-A')
       expect.assertions(1)
       return extractor.getInlineStyleTags({ nonce: 'testnonce' }).then(data =>
@@ -257,6 +316,28 @@ body {
 </style>"
 `),
       )
+    })
+
+    it('should add extraProps if specified - function argument', () => {
+      extractor.addChunk('letters-A')
+      expect.assertions(1)
+      return extractor
+        .getInlineStyleTags(asset => ({ nonce: asset.chunk }))
+        .then(data =>
+          expect(data).toMatchInlineSnapshot(`
+"<style type=\\"text/css\\" data-chunk=\\"main\\" nonce=\\"main\\">
+h1 {
+  color: cyan;
+}
+</style>
+<style type=\\"text/css\\" data-chunk=\\"letters-A\\" nonce=\\"letters-A\\">
+body {
+  background: pink;
+}
+
+</style>"
+`),
+        )
     })
   })
 
@@ -309,7 +390,7 @@ Array [
 `)
     })
 
-    it('should add extraProps if specified', () => {
+    it('should add extraProps if specified - object argument', () => {
       extractor.addChunk('letters-A')
       expect(extractor.getStyleElements({ nonce: 'testnonce' }))
         .toMatchInlineSnapshot(`
@@ -324,6 +405,27 @@ Array [
     data-chunk="letters-A"
     href="/dist/node/letters-A.css"
     nonce="testnonce"
+    rel="stylesheet"
+  />,
+]
+`)
+    })
+
+    it('should add extraProps if specified - function argument', () => {
+      extractor.addChunk('letters-A')
+      expect(extractor.getStyleElements(asset => ({ nonce: asset.chunk })))
+        .toMatchInlineSnapshot(`
+Array [
+  <link
+    data-chunk="main"
+    href="/dist/node/main.css"
+    nonce="main"
+    rel="stylesheet"
+  />,
+  <link
+    data-chunk="letters-A"
+    href="/dist/node/letters-A.css"
+    nonce="letters-A"
     rel="stylesheet"
   />,
 ]
@@ -417,7 +519,7 @@ body {
 `)
     })
 
-    it('should add extraProps if specified', () => {
+    it('should add extraProps if specified - object argument', () => {
       extractor.addChunk('letters-A')
       expect(extractor.getLinkTags({ nonce: 'testnonce' }))
         .toMatchInlineSnapshot(`
@@ -427,6 +529,19 @@ body {
 <link data-chunk=\\"letters-A\\" rel=\\"preload\\" as=\\"script\\" href=\\"/dist/node/letters-A.js\\" nonce=\\"testnonce\\">
 <link data-parent-chunk=\\"main\\" rel=\\"preload\\" as=\\"script\\" href=\\"/dist/node/letters-C.js\\" nonce=\\"testnonce\\">
 <link data-parent-chunk=\\"main\\" rel=\\"prefetch\\" as=\\"script\\" href=\\"/dist/node/letters-D.js\\" nonce=\\"testnonce\\">"
+`)
+    })
+
+    it('should add extraProps if specified - function argument', () => {
+      extractor.addChunk('letters-A')
+      expect(extractor.getLinkTags(asset => ({ nonce: asset.chunk })))
+        .toMatchInlineSnapshot(`
+"<link data-chunk=\\"main\\" rel=\\"preload\\" as=\\"style\\" href=\\"/dist/node/main.css\\" nonce=\\"main\\">
+<link data-chunk=\\"main\\" rel=\\"preload\\" as=\\"script\\" href=\\"/dist/node/main.js\\" nonce=\\"main\\">
+<link data-chunk=\\"letters-A\\" rel=\\"preload\\" as=\\"style\\" href=\\"/dist/node/letters-A.css\\" nonce=\\"letters-A\\">
+<link data-chunk=\\"letters-A\\" rel=\\"preload\\" as=\\"script\\" href=\\"/dist/node/letters-A.js\\" nonce=\\"letters-A\\">
+<link data-parent-chunk=\\"main\\" rel=\\"preload\\" as=\\"script\\" href=\\"/dist/node/letters-C.js\\" nonce=\\"main\\">
+<link data-parent-chunk=\\"main\\" rel=\\"prefetch\\" as=\\"script\\" href=\\"/dist/node/letters-D.js\\" nonce=\\"main\\">"
 `)
     })
   })

--- a/website/src/pages/docs/api-loadable-server.mdx
+++ b/website/src/pages/docs/api-loadable-server.mdx
@@ -58,9 +58,9 @@ const app = <App />
 
 Get scripts as a string of `<script>` tags.
 
-| Arguments    | Description                               |
-| ------------ | ----------------------------------------- |
-| `attributes` | Optional attributes added to script tags. |
+| Arguments                | Description                                                                                                 |
+| ------------------------ | ----------------------------------------------------------------------------------------------------------- |
+| `attributes` or `attrFn` | Optional attributes added to script tags, or a function that receives a `chunk` and returns the attributes. |
 
 ```js
 const body = `<body><div id="root">${html}</div>${chunkExtractor.getScriptTags()}</body>`
@@ -70,9 +70,9 @@ const body = `<body><div id="root">${html}</div>${chunkExtractor.getScriptTags()
 
 Get scripts as an array of React `<script>` elements.
 
-| Arguments    | Description                                   |
-| ------------ | --------------------------------------------- |
-| `attributes` | Optional attributes added to script elements. |
+| Arguments                | Description                                                                                                     |
+| ------------------------ | --------------------------------------------------------------------------------------------------------------- |
+| `attributes` or `attrFn` | Optional attributes added to script elements, or a function that receives a `chunk` and returns the attributes. |
 
 ```js
 const body = renderToString(
@@ -87,9 +87,9 @@ const body = renderToString(
 
 Get "prefetch" and "preload" links as a string of `<link>` tags.
 
-| Arguments    | Description                             |
-| ------------ | --------------------------------------- |
-| `attributes` | Optional attributes added to link tags. |
+| Arguments                | Description                                                                                               |
+| ------------------------ | --------------------------------------------------------------------------------------------------------- |
+| `attributes` or `attrFn` | Optional attributes added to link tags, or a function that receives a `chunk` and returns the attributes. |
 
 ```js
 const head = `<head>${chunkExtractor.getLinkTags()}</head>`
@@ -99,9 +99,9 @@ const head = `<head>${chunkExtractor.getLinkTags()}</head>`
 
 Get "prefetch" and "preload" links as an array of React `<link>` elements.
 
-| Arguments    | Description                                 |
-| ------------ | ------------------------------------------- |
-| `attributes` | Optional attributes added to link elements. |
+| Arguments                | Description                                                                                                   |
+| ------------------------ | ------------------------------------------------------------------------------------------------------------- |
+| `attributes` or `attrFn` | Optional attributes added to link elements, or a function that receives a `chunk` and returns the attributes. |
 
 ```js
 const head = renderToString(<head>{chunkExtractor.getLinkElements()}</head>)
@@ -111,9 +111,9 @@ const head = renderToString(<head>{chunkExtractor.getLinkElements()}</head>)
 
 Get style links as a string of `<link>` tags.
 
-| Arguments    | Description                              |
-| ------------ | ---------------------------------------- |
-| `attributes` | Optional attributes added to style tags. |
+| Arguments                | Description                                                                                                |
+| ------------------------ | ---------------------------------------------------------------------------------------------------------- |
+| `attributes` or `attrFn` | Optional attributes added to style tags, or a function that receives a `chunk` and returns the attributes. |
 
 ```js
 const head = `<head>${chunkExtractor.getStyleTags()}</head>`
@@ -131,9 +131,9 @@ const head = renderToString(<head>{chunkExtractor.getStyleElements()}</head>)
 
 Get inline style links as a string of `<link>` tags (returns a promise).
 
-| Arguments    | Description                              |
-| ------------ | ---------------------------------------- |
-| `attributes` | Optional attributes added to style tags. |
+| Arguments                | Description                                                                                                |
+| ------------------------ | ---------------------------------------------------------------------------------------------------------- |
+| `attributes` or `attrFn` | Optional attributes added to style tags, or a function that receives a `chunk` and returns the attributes. |
 
 ```js
 chunkExtractor.getInlineStyleTags()
@@ -146,9 +146,9 @@ chunkExtractor.getInlineStyleTags()
 
 Get inline style links as an array of React `<link>` elements (returns a promise).
 
-| Arguments    | Description                                  |
-| ------------ | -------------------------------------------- |
-| `attributes` | Optional attributes added to style elements. |
+| Arguments                | Description                                                                                                    |
+| ------------------------ | -------------------------------------------------------------------------------------------------------------- |
+| `attributes` or `attrFn` | Optional attributes added to style elements, or a function that receives a `chunk` and returns the attributes. |
 
 ```js
 chunkExtractor.getInlineStyleElements()


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

Allow the attributes arguments to be a function to possibly map the chunks to attributes.

Currently it uses the same argument but checks if it is a function or an object.

Also the attribute function could get `null` as an argument in case the `__LOADABLE_REQUIRED_CHUNKS__` tag

Looking forward to your feedback.

## Test plan

tests included
