### PR TITLE
docs: add note that `@loadable/babel-plugin` is not only needed in SSR

### DIFF
--- a/website/src/pages/docs/getting-started.mdx
+++ b/website/src/pages/docs/getting-started.mdx
@@ -18,7 +18,7 @@ npm install @loadable/component
 yarn add @loadable/component
 ```
 
-> `@loadable/server`, `@loadable/webpack-plugin` and `@loadable/babel-plugin` are only required for [Server Side Rendering](/docs/server-side-rendering/).
+> `@loadable/babel-plugin` is required for [Server Side Rendering](/docs/server-side-rendering/) and automatic chunk names generation. `@loadable/server` and `@loadable/webpack-plugin` are only required for [Server Side Rendering](/docs/server-side-rendering/).
 
 ## Split your first component
 


### PR DESCRIPTION
## Summary

After migrating from `loadable-components` package I have noticed that even I'm not using SSR but `@loadable/babel-plugin` (`loadable-components/babel` earlier) is required in my setup. 

This change extends Installation note by exposing that `babel-plugin` is also needed when you use chunks.