### PR TITLE
feat(ChunkExtractor): support publicPath override

### DIFF
--- a/packages/server/src/ChunkExtractor.js
+++ b/packages/server/src/ChunkExtractor.js
@@ -153,8 +153,15 @@ function isValidChunkAsset(chunkAsset) {
 }
 
 class ChunkExtractor {
-  constructor({ statsFile, stats, entrypoints = ['main'], outputPath } = []) {
+  constructor({
+    statsFile,
+    stats,
+    entrypoints = ['main'],
+    outputPath,
+    publicPath,
+  } = {}) {
     this.stats = stats || smartRequire(statsFile)
+    this.publicPath = publicPath || this.stats.publicPath
     this.outputPath = outputPath || this.stats.outputPath
     this.statsFile = statsFile
     this.entrypoints = Array.isArray(entrypoints) ? entrypoints : [entrypoints]
@@ -162,8 +169,7 @@ class ChunkExtractor {
   }
 
   resolvePublicUrl(filename) {
-    const { publicPath } = this.stats
-    return joinURLPath(publicPath, filename)
+    return joinURLPath(this.publicPath, filename)
   }
 
   getChunkGroup(chunk) {

--- a/packages/server/src/ChunkExtractor.test.js
+++ b/packages/server/src/ChunkExtractor.test.js
@@ -12,6 +12,26 @@ describe('ChunkExtrator', () => {
     })
   })
 
+  describe('#resolvePublicUrl', () => {
+    it('should default to using stats.publicPath', () => {
+      expect(extractor.resolvePublicUrl('main.js')).toEqual(
+        '/dist/node/main.js',
+      )
+    })
+
+    it('should use publicPath from ChunkExtractor options', () => {
+      extractor = new ChunkExtractor({
+        stats,
+        publicPath: 'https://cdn.example.org/v1.1.0/',
+        outputPath: path.resolve(__dirname, '../__fixtures__'),
+      })
+
+      expect(extractor.resolvePublicUrl('main.js')).toEqual(
+        'https://cdn.example.org/v1.1.0/main.js',
+      )
+    })
+  })
+
   describe('#stats', () => {
     it('should load stats from file', () => {
       extractor = new ChunkExtractor({
@@ -226,6 +246,33 @@ Array [
     data-chunk="letters-A"
     nonce="letters-A"
     src="/dist/node/letters-A.js"
+  />,
+]
+`)
+    })
+
+    it('should use publicPath from options', () => {
+      extractor = new ChunkExtractor({
+        stats,
+        publicPath: 'https://cdn.example.org/v1.1.0/',
+        outputPath: path.resolve(__dirname, '../__fixtures__'),
+      })
+
+      expect(extractor.getScriptElements()).toMatchInlineSnapshot(`
+Array [
+  <script
+    dangerouslySetInnerHTML={
+      Object {
+        "__html": "[]",
+      }
+    }
+    id="__LOADABLE_REQUIRED_CHUNKS__"
+    type="application/json"
+  />,
+  <script
+    async={true}
+    data-chunk="main"
+    src="https://cdn.example.org/v1.1.0/main.js"
   />,
 ]
 `)

--- a/website/src/pages/docs/server-side-rendering.mdx
+++ b/website/src/pages/docs/server-side-rendering.mdx
@@ -199,3 +199,18 @@ import loadable from '@loadable/component'
 // This dynamic import will not be processed server-side
 const Other = loadable(() => import('./Other'), { ssr: false })
 ```
+
+## Override `stats.publicPath` at runtime
+
+To override `stats.publicPath` at runtime, pass in a custom `publicPath` to the `ChunkExtractor` constructor:
+
+```js
+import { ChunkExtractor } from '@loadable/server'
+
+const statsFile = path.resolve('../dist/loadable-stats.json')
+
+const extractor = new ChunkExtractor({
+  statsFile,
+  publicPath: 'https://cdn.example.org/v1.1.0/',
+})
+```


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary
Add support for passing `publicPath` to `ChunkExtractor`. This will allow consumers to override `publicPath` at runtime.

Currently in our usage we are loading the stats file, manually overriding the `publicPath`, and then injecting that stats object into `ChunkExtractor`. This seems like a simple enough change that it warrants being supported out-of-the-box.

Formatted docs section: https://deploy-preview-292--loadable.netlify.com/docs/server-side-rendering/#override-statspublicpath-at-runtime

closes https://github.com/smooth-code/loadable-components/issues/269

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan
Added new test cases to `packages/server/src/ChunkExtractor.test.js`.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
