### PR TITLE
add s to speed and reduce so copy is gramatically correct

### DIFF
--- a/website/src/pages/docs/code-splitting.mdx
+++ b/website/src/pages/docs/code-splitting.mdx
@@ -6,7 +6,7 @@ order: 10
 
 # Code Splitting?
 
-Code Splitting is an efficient way to reduce your bundle size: it speed up the loading of your application and reduce the payload size of your application.
+Code Splitting is an efficient way to reduce your bundle size: it speeds up the loading of your application and reduces the payload size of your application.
 
 Bundling is great, but as your app grows, your bundle will grow too. Especially if you are including large third-party libraries. You need to keep an eye on the code you are including in your bundle so that you don’t accidentally make it so large that your app takes a long time to load.
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

The current use of `speed` and `reduce` on the code-splitting page of the documentation is incorrect. To be grammatically correct, I've added an `s`. 

## Test plan

No tests needed as it is just a grammar update to the documentation 😃 
