### PR TITLE
Allow waiting on a preload

### DIFF
--- a/packages/component/src/createLoadable.js
+++ b/packages/component/src/createLoadable.js
@@ -192,7 +192,7 @@ function createLoadable({ resolve = identity, render, onLoad }) {
       if (typeof window === 'undefined') {
         throw new Error('`preload` cannot be called server-side')
       }
-      ctor.requireAsync(props)
+      return ctor.requireAsync(props).then(() => {})
     }
 
     return Loadable


### PR DESCRIPTION
## Summary
Allow waiting on preload.

My main use case is to prevent displaying a fallback when routing between pages. Example:

```
const wait = ms => new Promise((resolve) => setTimeout(resolve, ms));
await Promise.race([MyLoadableComponent.preload(), wait(100)])
showPage();
```
