### PR TITLE
Return promise from component.preload()

### DIFF
--- a/packages/component/package.json
+++ b/packages/component/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@loadable/component",
   "description": "React code splitting made easy.",
-  "version": "5.7.0",
+  "version": "5.8.0-alpha.0",
   "main": "dist/loadable.cjs.js",
   "module": "dist/loadable.es.js",
   "jsnext:main": "dist/loadable.es.js",

--- a/packages/component/package.json
+++ b/packages/component/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@loadable/component",
   "description": "React code splitting made easy.",
-  "version": "5.8.0-alpha.0",
+  "version": "5.7.0",
   "main": "dist/loadable.cjs.js",
   "module": "dist/loadable.es.js",
   "jsnext:main": "dist/loadable.es.js",

--- a/packages/component/src/createLoadable.js
+++ b/packages/component/src/createLoadable.js
@@ -192,7 +192,8 @@ function createLoadable({ resolve = identity, render, onLoad }) {
       if (typeof window === 'undefined') {
         throw new Error('`preload` cannot be called server-side')
       }
-      ctor.requireAsync(props)
+
+      return ctor.requireAsync(props)
     }
 
     return Loadable


### PR DESCRIPTION
**Preface:** I'm not sure if this is the "correct" solution to my problem (maybe I missed something in the documentation) but this was the only way I could find to hook into the process that actually loads the component.

## Summary

The problem I've been experiencing is that I needed to be able to call `Component.preload()` to load a component, but _also **wait** for `preload()` to complete_ **before** rendering the route.

(We're stuck using `react-router` `3.x` for the time being...)

This PR solves our problem by simply returning `ctor. requireAsync(props)` from the `preload()` function, as `requireAsync` already returns a promise that resolves once the component is loaded.

## Test plan

Where are the tests for `loadable/component`? Am I missing something?