### PR TITLE
Multiple React applications on same page support

### DIFF
--- a/packages/component/src/loadableReady.js
+++ b/packages/component/src/loadableReady.js
@@ -1,11 +1,14 @@
 /* eslint-disable no-underscore-dangle, camelcase */
 /* eslint-env browser */
 import { warn } from './util'
-import { LOADABLE_REQUIRED_CHUNKS_KEY } from './sharedInternals'
+import { getRequiredChunkKey } from './sharedInternals'
 
 const BROWSER = typeof window !== 'undefined'
 
-export default function loadableReady(done = () => {}, appName = '') {
+export default function loadableReady(
+  done = () => {},
+  { namespace = '' } = {},
+) {
   if (!BROWSER) {
     warn('`loadableReady()` must be called in browser only')
     done()
@@ -14,7 +17,7 @@ export default function loadableReady(done = () => {}, appName = '') {
 
   let requiredChunks = null
   if (BROWSER) {
-    const dataElement = document.getElementById(appName + LOADABLE_REQUIRED_CHUNKS_KEY)
+    const dataElement = document.getElementById(getRequiredChunkKey(namespace))
     if (dataElement) {
       requiredChunks = JSON.parse(dataElement.textContent)
     }

--- a/packages/component/src/loadableReady.js
+++ b/packages/component/src/loadableReady.js
@@ -5,7 +5,7 @@ import { LOADABLE_REQUIRED_CHUNKS_KEY } from './sharedInternals'
 
 const BROWSER = typeof window !== 'undefined'
 
-export default function loadableReady(done = () => {}) {
+export default function loadableReady(done = () => {}, appName = '') {
   if (!BROWSER) {
     warn('`loadableReady()` must be called in browser only')
     done()
@@ -14,7 +14,7 @@ export default function loadableReady(done = () => {}) {
 
   let requiredChunks = null
   if (BROWSER) {
-    const dataElement = document.getElementById(LOADABLE_REQUIRED_CHUNKS_KEY)
+    const dataElement = document.getElementById(appName + LOADABLE_REQUIRED_CHUNKS_KEY)
     if (dataElement) {
       requiredChunks = JSON.parse(dataElement.textContent)
     }

--- a/packages/component/src/sharedInternals.js
+++ b/packages/component/src/sharedInternals.js
@@ -1,3 +1,6 @@
 export { invariant } from './util'
 export { default as Context } from './Context'
-export const LOADABLE_REQUIRED_CHUNKS_KEY = '__LOADABLE_REQUIRED_CHUNKS__'
+const LOADABLE_REQUIRED_CHUNKS_KEY = '__LOADABLE_REQUIRED_CHUNKS__'
+export function getRequiredChunkKey(namespace) {
+  return `${namespace}${LOADABLE_REQUIRED_CHUNKS_KEY}`
+}

--- a/packages/server/src/ChunkExtractor.js
+++ b/packages/server/src/ChunkExtractor.js
@@ -5,7 +5,7 @@ import uniq from 'lodash/uniq'
 import uniqBy from 'lodash/uniqBy'
 import flatMap from 'lodash/flatMap'
 import React from 'react'
-import { invariant, LOADABLE_REQUIRED_CHUNKS_KEY } from './sharedInternals'
+import { invariant, getRequiredChunkKey } from './sharedInternals'
 import ChunkExtractorManager from './ChunkExtractorManager'
 import { smartRequire, joinURLPath } from './util'
 
@@ -156,14 +156,14 @@ function isValidChunkAsset(chunkAsset) {
 
 class ChunkExtractor {
   constructor({
-    appName = '',
     statsFile,
     stats,
     entrypoints = ['main'],
+    namespace = '',
     outputPath,
     publicPath,
   } = {}) {
-    this.appName = appName
+    this.namespace = namespace
     this.stats = stats || smartRequire(statsFile)
     this.publicPath = publicPath || this.stats.publicPath
     this.outputPath = outputPath || this.stats.outputPath
@@ -262,7 +262,9 @@ class ChunkExtractor {
   }
 
   getRequiredChunksScriptTag(extraProps) {
-    return `<script id="${this.appName}${LOADABLE_REQUIRED_CHUNKS_KEY}" type="application/json"${extraPropsToString(
+    return `<script id="${getRequiredChunkKey(
+      this.namespace,
+    )}" type="application/json"${extraPropsToString(
       null,
       extraProps,
     )}>${this.getRequiredChunksScriptContent()}</script>`
@@ -272,7 +274,7 @@ class ChunkExtractor {
     return (
       <script
         key="required"
-        id={this.appName + LOADABLE_REQUIRED_CHUNKS_KEY}
+        id={getRequiredChunkKey(this.namespace)}
         type="application/json"
         dangerouslySetInnerHTML={{
           __html: this.getRequiredChunksScriptContent(),

--- a/packages/server/src/ChunkExtractor.js
+++ b/packages/server/src/ChunkExtractor.js
@@ -156,12 +156,14 @@ function isValidChunkAsset(chunkAsset) {
 
 class ChunkExtractor {
   constructor({
+    appName = '',
     statsFile,
     stats,
     entrypoints = ['main'],
     outputPath,
     publicPath,
   } = {}) {
+    this.appName = appName
     this.stats = stats || smartRequire(statsFile)
     this.publicPath = publicPath || this.stats.publicPath
     this.outputPath = outputPath || this.stats.outputPath
@@ -260,7 +262,7 @@ class ChunkExtractor {
   }
 
   getRequiredChunksScriptTag(extraProps) {
-    return `<script id="${LOADABLE_REQUIRED_CHUNKS_KEY}" type="application/json"${extraPropsToString(
+    return `<script id="${this.appName}${LOADABLE_REQUIRED_CHUNKS_KEY}" type="application/json"${extraPropsToString(
       null,
       extraProps,
     )}>${this.getRequiredChunksScriptContent()}</script>`
@@ -270,7 +272,7 @@ class ChunkExtractor {
     return (
       <script
         key="required"
-        id={LOADABLE_REQUIRED_CHUNKS_KEY}
+        id={this.appName + LOADABLE_REQUIRED_CHUNKS_KEY}
         type="application/json"
         dangerouslySetInnerHTML={{
           __html: this.getRequiredChunksScriptContent(),

--- a/packages/server/src/ChunkExtractor.test.js
+++ b/packages/server/src/ChunkExtractor.test.js
@@ -70,7 +70,7 @@ describe('ChunkExtrator', () => {
 
     it('should return main script tag without chunk with namespaced required chunks id', () => {
       extractor = new ChunkExtractor({
-        appName: 'testapp',
+        namespace: 'testapp',
         stats,
         outputPath: path.resolve(__dirname, '../__fixtures__'),
       })
@@ -78,7 +78,7 @@ describe('ChunkExtrator', () => {
 "<script id=\\"testapp__LOADABLE_REQUIRED_CHUNKS__\\" type=\\"application/json\\">[]</script>
 <script async data-chunk=\\"main\\" src=\\"/dist/node/main.js\\"></script>"
 `)
-    });
+    })
 
     it('should return other chunks if referenced', () => {
       extractor.addChunk('letters-A')
@@ -125,7 +125,7 @@ describe('ChunkExtrator', () => {
   describe('#getScriptElements', () => {
     it('should return main script tag without chunk with namespaced id for loadable chunks', () => {
       extractor = new ChunkExtractor({
-        appName: 'testapp',
+        namespace: 'testapp',
         stats,
         outputPath: path.resolve(__dirname, '../__fixtures__'),
       })

--- a/packages/server/src/ChunkExtractor.test.js
+++ b/packages/server/src/ChunkExtractor.test.js
@@ -68,6 +68,18 @@ describe('ChunkExtrator', () => {
 `)
     })
 
+    it('should return main script tag without chunk with namespaced required chunks id', () => {
+      extractor = new ChunkExtractor({
+        appName: 'testapp',
+        stats,
+        outputPath: path.resolve(__dirname, '../__fixtures__'),
+      })
+      expect(extractor.getScriptTags()).toMatchInlineSnapshot(`
+"<script id=\\"testapp__LOADABLE_REQUIRED_CHUNKS__\\" type=\\"application/json\\">[]</script>
+<script async data-chunk=\\"main\\" src=\\"/dist/node/main.js\\"></script>"
+`)
+    });
+
     it('should return other chunks if referenced', () => {
       extractor.addChunk('letters-A')
       expect(extractor.getScriptTags()).toMatchInlineSnapshot(`
@@ -111,6 +123,32 @@ describe('ChunkExtrator', () => {
   })
 
   describe('#getScriptElements', () => {
+    it('should return main script tag without chunk with namespaced id for loadable chunks', () => {
+      extractor = new ChunkExtractor({
+        appName: 'testapp',
+        stats,
+        outputPath: path.resolve(__dirname, '../__fixtures__'),
+      })
+      expect(extractor.getScriptElements()).toMatchInlineSnapshot(`
+Array [
+  <script
+    dangerouslySetInnerHTML={
+      Object {
+        "__html": "[]",
+      }
+    }
+    id="testapp__LOADABLE_REQUIRED_CHUNKS__"
+    type="application/json"
+  />,
+  <script
+    async={true}
+    data-chunk="main"
+    src="/dist/node/main.js"
+  />,
+]
+`)
+    })
+
     it('should return main script tag without chunk', () => {
       expect(extractor.getScriptElements()).toMatchInlineSnapshot(`
 Array [

--- a/packages/server/src/sharedInternals.js
+++ b/packages/server/src/sharedInternals.js
@@ -4,7 +4,7 @@ import { __SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED } from '@loadable/co
 const {
   invariant,
   Context,
-  LOADABLE_REQUIRED_CHUNKS_KEY,
+  getRequiredChunkKey,
 } = __SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED
 
-export { invariant, Context, LOADABLE_REQUIRED_CHUNKS_KEY }
+export { invariant, Context, getRequiredChunkKey }

--- a/website/src/pages/docs/api-loadable-component.mdx
+++ b/website/src/pages/docs/api-loadable-component.mdx
@@ -16,6 +16,7 @@ Create a loadable component.
 | `options`          | Optional options.                                                    |
 | `options.fallback` | Fallback displayed during the loading.                               |
 | `options.ssr`      | If `false`, it will not be processed server-side. Default to `true`. |
+| `appName`          | Use this if you have multiple loadable components in same screen.    |
 
 ```js
 import loadable from '@loadable/component'

--- a/website/src/pages/docs/api-loadable-component.mdx
+++ b/website/src/pages/docs/api-loadable-component.mdx
@@ -16,7 +16,6 @@ Create a loadable component.
 | `options`          | Optional options.                                                    |
 | `options.fallback` | Fallback displayed during the loading.                               |
 | `options.ssr`      | If `false`, it will not be processed server-side. Default to `true`. |
-| `appName`          | Use this if you have multiple loadable components in same screen.    |
 
 ```js
 import loadable from '@loadable/component'
@@ -103,3 +102,22 @@ A component created using `loadable.lib` or `lazy.lib`.
 | `ref`      | Accepts a ref, populated when the library is loaded. |
 | `fallback` | Fallback displayed during the loading.               |
 | `...`      | Props are forwarded as first argument of `loadFn`    |
+
+## loadableReady
+
+Wait for all loadable components to be loaded. This method must only be used with Server Side Rendering, see [Server Side Rendering guide](/docs/server-side-rendering/).
+
+| Arguments           | Description                                                                               |
+| ------------------- | ----------------------------------------------------------------------------------------- |
+| `done`              | Function called when all components are loaded.                                           |
+| `options`           | Optional options.                                                                         |
+| `options.namespace` | Namespace of your application (use only if you have several React apps on the same page). |
+
+```js
+import { loadableReady } from '@loadable/component'
+
+loadableReady(() => {
+  const root = document.getElementById('main')
+  hydrate(<App />, root)
+})
+```

--- a/website/src/pages/docs/api-loadable-server.mdx
+++ b/website/src/pages/docs/api-loadable-server.mdx
@@ -10,14 +10,14 @@ order: 20
 
 Used to collect chunks server-side and get them as script tags or script elements.
 
-| Arguments             | Description                                                       |
-| --------------------- | ----------------------------------------------------------------- |
-| `options`             | An object options.                                                |
-| `options.statsFile`   | Stats file path generated using `@loadable/webpack-plugin`.       |
-| `options.stats`       | Stats generated using `@loadable/webpack-plugin`.                 |
-| `options.entrypoints` | Webpack entrypoints to load (default to `["main"]`).              |
-| `options.outputPath`  | Optional output path (only for `requireEntrypoint`).              |
-| `options.appName`     | Use this if you have multiple loadable components in same screen. |
+| Arguments             | Description                                                                               |
+| --------------------- | ----------------------------------------------------------------------------------------- |
+| `options`             | An object options.                                                                        |
+| `options.statsFile`   | Stats file path generated using `@loadable/webpack-plugin`.                               |
+| `options.stats`       | Stats generated using `@loadable/webpack-plugin`.                                         |
+| `options.entrypoints` | Webpack entrypoints to load (default to `["main"]`).                                      |
+| `options.outputPath`  | Optional output path (only for `requireEntrypoint`).                                      |
+| `options.namespace`   | Namespace of your application (use only if you have several React apps on the same page). |
 
 You must specify either `statsFile` or `stats` to be able to use `ChunkExtractor`.
 

--- a/website/src/pages/docs/api-loadable-server.mdx
+++ b/website/src/pages/docs/api-loadable-server.mdx
@@ -10,13 +10,14 @@ order: 20
 
 Used to collect chunks server-side and get them as script tags or script elements.
 
-| Arguments             | Description                                                 |
-| --------------------- | ----------------------------------------------------------- |
-| `options`             | An object options.                                          |
-| `options.statsFile`   | Stats file path generated using `@loadable/webpack-plugin`. |
-| `options.stats`       | Stats generated using `@loadable/webpack-plugin`.           |
-| `options.entrypoints` | Webpack entrypoints to load (default to `["main"]`).        |
-| `options.outputPath`  | Optional output path (only for `requireEntrypoint`).        |
+| Arguments             | Description                                                       |
+| --------------------- | ----------------------------------------------------------------- |
+| `options`             | An object options.                                                |
+| `options.statsFile`   | Stats file path generated using `@loadable/webpack-plugin`.       |
+| `options.stats`       | Stats generated using `@loadable/webpack-plugin`.                 |
+| `options.entrypoints` | Webpack entrypoints to load (default to `["main"]`).              |
+| `options.outputPath`  | Optional output path (only for `requireEntrypoint`).              |
+| `options.appName`     | Use this if you have multiple loadable components in same screen. |
 
 You must specify either `statsFile` or `stats` to be able to use `ChunkExtractor`.
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->
Fixes #311 

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
Loadable components currently doesn't support having multiple react apps on the same page. This is because it uses the hardcoded id of `__LOADABLE_REQUIRED_CHUNKS__`  in a script tag to check if a chunk has loaded. This PR aims to add the feature to add a namespace to each app to make this possible. 

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
Added test cases on the server side to make sure that the namespace was being added to the `script` id. 
On the client side, verified manually if loading 2 different react apps triggers 2 different `loadable` events