### PR TITLE
Making preload built-in chainable

### DIFF
--- a/packages/component/src/createLoadable.js
+++ b/packages/component/src/createLoadable.js
@@ -192,7 +192,7 @@ function createLoadable({ resolve = identity, render, onLoad }) {
       if (typeof window === 'undefined') {
         throw new Error('`preload` cannot be called server-side')
       }
-      ctor.requireAsync(props)
+      return ctor.requireAsync(props)
     }
 
     return Loadable


### PR DESCRIPTION
Return a `promise` instead of undefined from preload built-in for easy `chaining`.
