### PR TITLE
use more performant url join impl

### DIFF
--- a/packages/server/src/util.js
+++ b/packages/server/src/util.js
@@ -17,7 +17,10 @@ export const smartRequire = modulePath => {
   return eval('module.require')(modulePath)
 }
 
-export const joinURLPath = (...paths) => {
-  const cleanPaths = paths.map(path => path.replace(/\/$/, ''))
-  return cleanPaths.join('/')
+export const joinURLPath = (publicPath, filename) => {
+  if (publicPath.substr(-1) === '/') {
+    return `${publicPath}${filename}`
+  }
+
+  return `${publicPath}/${filename}`
 }


### PR DESCRIPTION
## Summary

- Regex can be [heavy handed](https://ebaytech.berlin/slow-regexp-dying-node-js-7a862ed6ea65).

## Test plan

```sh
yarn test packages/server/src/util.test.js
yarn run v1.16.0
$ jest packages/server/src/util.test.js
 PASS  packages/server/src/util.test.js
  util
    #joinURLPath
      ✓ should join paths with relative public path (2ms)
      ✓ should join paths starting with "/" (1ms)
      ✓ should join paths with absolute public path
      ✓ should join paths with protocol free public path

Test Suites: 1 passed, 1 total
Tests:       4 passed, 4 total
Snapshots:   0 total
Time:        0.869s, estimated 1s
Ran all test suites matching /packages\/server\/src\/util.test.js/i.
✨  Done in 2.02s.
```
