### PR TITLE
fix: add Object.is ponyfill to improve ie compatibility

### DIFF
--- a/packages/component/src/createLoadable.js
+++ b/packages/component/src/createLoadable.js
@@ -2,6 +2,7 @@
 import React from 'react'
 import { invariant } from './util'
 import Context from './Context'
+import objectIs from './ponyfills/objectIs';
 
 function resolveConstructor(ctor) {
   if (typeof ctor === 'function') {
@@ -97,7 +98,7 @@ function createLoadable({ resolve = identity, render, onLoad }) {
 
       componentDidUpdate(prevProps, prevState) {
         // Component is reloaded if the cacheKey has changed
-        if (!Object.is(prevState.cacheKey, this.state.cacheKey)) {
+        if (!objectIs(prevState.cacheKey, this.state.cacheKey)) {
           this.promise = null
           this.loadAsync()
         }

--- a/packages/component/src/ponyfills/objectIs.js
+++ b/packages/component/src/ponyfills/objectIs.js
@@ -1,0 +1,12 @@
+// https://developer.mozilla.org/ca/docs/Web/JavaScript/Reference/Global_Objects/Object/is#Polyfill_for_non-ES6_browsers
+function objectIs(x, y) {
+  // SameValue algorithm
+  if (x === y) {
+    return x !== 0 || 1 / x === 1 / y
+  }
+  // NaN == NaN
+  // eslint-disable-next-line no-self-compare
+  return x !== x && y !== y
+}
+
+export default objectIs


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

use ponyfill to replace `Object.is` due to ie compatibility.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
```bash
➜  loadable-components git:(add-Object.is-ponyfill) ✗ yarn test
yarn run v1.16.0
$ jest
 PASS  packages/server/src/util.test.js
 PASS  packages/server/src/ChunkExtractor.test.js
 PASS  packages/component/src/loadable.test.js
 PASS  packages/babel-plugin/src/index.test.js

Test Suites: 4 passed, 4 total
Tests:       83 passed, 83 total
Snapshots:   55 passed, 55 total
Time:        3.961s
Ran all test suites.
Done in 5.60s.

```