### PR TITLE
Generates chunk names consistently

### DIFF
--- a/packages/babel-plugin/src/__snapshots__/index.test.js.snap
+++ b/packages/babel-plugin/src/__snapshots__/index.test.js.snap
@@ -491,7 +491,7 @@ exports[`plugin simple import should transform path into "chunk-friendly" name 1
 exports[`plugin simple import should transform to same chunk name when import paths are different 1`] = `
 "loadable({
   chunkName() {
-    return \\"Users-dthonse-workspace-loadable-components-baz-foo-bar\\";
+    return \\"home-travis-build-smooth-code-loadable-components-baz-foo-bar\\";
   },
 
   isReady(props) {
@@ -503,7 +503,7 @@ exports[`plugin simple import should transform to same chunk name when import pa
   },
 
   requireAsync: () => import(
-  /* webpackChunkName: \\"Users-dthonse-workspace-loadable-components-baz-foo-bar\\" */
+  /* webpackChunkName: \\"home-travis-build-smooth-code-loadable-components-baz-foo-bar\\" */
   './foo/bar'),
 
   requireSync(props) {
@@ -530,7 +530,7 @@ exports[`plugin simple import should transform to same chunk name when import pa
 exports[`plugin simple import should transform to same chunk name when import paths are different 2`] = `
 "loadable({
   chunkName() {
-    return \\"Users-dthonse-workspace-loadable-components-baz-foo-bar\\";
+    return \\"home-travis-build-smooth-code-loadable-components-baz-foo-bar\\";
   },
 
   isReady(props) {
@@ -542,7 +542,7 @@ exports[`plugin simple import should transform to same chunk name when import pa
   },
 
   requireAsync: () => import(
-  /* webpackChunkName: \\"Users-dthonse-workspace-loadable-components-baz-foo-bar\\" */
+  /* webpackChunkName: \\"home-travis-build-smooth-code-loadable-components-baz-foo-bar\\" */
   './bar'),
 
   requireSync(props) {

--- a/packages/babel-plugin/src/__snapshots__/index.test.js.snap
+++ b/packages/babel-plugin/src/__snapshots__/index.test.js.snap
@@ -5,7 +5,7 @@ exports[`plugin Magic comment should remove only needed comments 1`] = `
 /* IMPORTANT! */
 {
   chunkName() {
-    return \\"moment\\";
+    return \\"baz-moment\\";
   },
 
   isReady(props) {
@@ -17,7 +17,7 @@ exports[`plugin Magic comment should remove only needed comments 1`] = `
   },
 
   requireAsync: () => import(
-  /* webpackChunkName: \\"moment\\" */
+  /* webpackChunkName: \\"baz-moment\\" */
   'moment'),
 
   requireSync(props) {
@@ -44,7 +44,7 @@ exports[`plugin Magic comment should remove only needed comments 1`] = `
 exports[`plugin Magic comment should transpile arrow functions 1`] = `
 "const load = {
   chunkName() {
-    return \\"moment\\";
+    return \\"baz-moment\\";
   },
 
   isReady(props) {
@@ -56,7 +56,7 @@ exports[`plugin Magic comment should transpile arrow functions 1`] = `
   },
 
   requireAsync: () => import(
-  /* webpackChunkName: \\"moment\\" */
+  /* webpackChunkName: \\"baz-moment\\" */
   'moment'),
 
   requireSync(props) {
@@ -83,7 +83,7 @@ exports[`plugin Magic comment should transpile arrow functions 1`] = `
 exports[`plugin Magic comment should transpile function expression 1`] = `
 "const load = {
   chunkName() {
-    return \\"moment\\";
+    return \\"baz-moment\\";
   },
 
   isReady(props) {
@@ -96,7 +96,7 @@ exports[`plugin Magic comment should transpile function expression 1`] = `
 
   requireAsync: function () {
     return import(
-    /* webpackChunkName: \\"moment\\" */
+    /* webpackChunkName: \\"baz-moment\\" */
     'moment');
   },
 
@@ -125,7 +125,7 @@ exports[`plugin Magic comment should transpile shortand properties 1`] = `
 "const obj = {
   load: {
     chunkName() {
-      return \\"moment\\";
+      return \\"baz-moment\\";
     },
 
     isReady(props) {
@@ -138,7 +138,7 @@ exports[`plugin Magic comment should transpile shortand properties 1`] = `
 
     requireAsync: () => {
       return import(
-      /* webpackChunkName: \\"moment\\" */
+      /* webpackChunkName: \\"baz-moment\\" */
       'moment');
     },
 
@@ -374,7 +374,7 @@ exports[`plugin aggressive import without "webpackChunkName" should support simp
 exports[`plugin loadable.lib should be transpiled too 1`] = `
 "loadable.lib({
   chunkName() {
-    return \\"moment\\";
+    return \\"baz-moment\\";
   },
 
   isReady(props) {
@@ -386,7 +386,7 @@ exports[`plugin loadable.lib should be transpiled too 1`] = `
   },
 
   requireAsync: () => import(
-  /* webpackChunkName: \\"moment\\" */
+  /* webpackChunkName: \\"baz-moment\\" */
   'moment'),
 
   requireSync(props) {
@@ -413,7 +413,7 @@ exports[`plugin loadable.lib should be transpiled too 1`] = `
 exports[`plugin simple import in a complex promise should work 1`] = `
 "loadable({
   chunkName() {
-    return \\"ModA\\";
+    return \\"baz-ModA\\";
   },
 
   isReady(props) {
@@ -425,7 +425,7 @@ exports[`plugin simple import in a complex promise should work 1`] = `
   },
 
   requireAsync: () => timeout(import(
-  /* webpackChunkName: \\"ModA\\" */
+  /* webpackChunkName: \\"baz-ModA\\" */
   './ModA'), 2000),
 
   requireSync(props) {
@@ -483,6 +483,84 @@ exports[`plugin simple import should transform path into "chunk-friendly" name 1
     }
 
     return eval('require.resolve')(\\"../foo/bar\\");
+  }
+
+});"
+`;
+
+exports[`plugin simple import should transform to same chunk name when import paths are different 1`] = `
+"loadable({
+  chunkName() {
+    return \\"Users-dthonse-workspace-loadable-components-baz-foo-bar\\";
+  },
+
+  isReady(props) {
+    if (typeof __webpack_modules__ !== 'undefined') {
+      return !!__webpack_modules__[this.resolve(props)];
+    }
+
+    return false;
+  },
+
+  requireAsync: () => import(
+  /* webpackChunkName: \\"Users-dthonse-workspace-loadable-components-baz-foo-bar\\" */
+  './foo/bar'),
+
+  requireSync(props) {
+    const id = this.resolve(props);
+
+    if (typeof __webpack_require__ !== 'undefined') {
+      return __webpack_require__(id);
+    }
+
+    return eval('module.require')(id);
+  },
+
+  resolve() {
+    if (require.resolveWeak) {
+      return require.resolveWeak(\\"./foo/bar\\");
+    }
+
+    return eval('require.resolve')(\\"./foo/bar\\");
+  }
+
+});"
+`;
+
+exports[`plugin simple import should transform to same chunk name when import paths are different 2`] = `
+"loadable({
+  chunkName() {
+    return \\"Users-dthonse-workspace-loadable-components-baz-foo-bar\\";
+  },
+
+  isReady(props) {
+    if (typeof __webpack_modules__ !== 'undefined') {
+      return !!__webpack_modules__[this.resolve(props)];
+    }
+
+    return false;
+  },
+
+  requireAsync: () => import(
+  /* webpackChunkName: \\"Users-dthonse-workspace-loadable-components-baz-foo-bar\\" */
+  './bar'),
+
+  requireSync(props) {
+    const id = this.resolve(props);
+
+    if (typeof __webpack_require__ !== 'undefined') {
+      return __webpack_require__(id);
+    }
+
+    return eval('module.require')(id);
+  },
+
+  resolve() {
+    if (require.resolveWeak) {
+      return require.resolveWeak(\\"./bar\\");
+    }
+
+    return eval('require.resolve')(\\"./bar\\");
   }
 
 });"
@@ -647,7 +725,7 @@ exports[`plugin simple import with "webpackChunkName" comment should use it even
 exports[`plugin simple import without "webpackChunkName" comment should add it 1`] = `
 "loadable({
   chunkName() {
-    return \\"ModA\\";
+    return \\"baz-ModA\\";
   },
 
   isReady(props) {
@@ -659,7 +737,7 @@ exports[`plugin simple import without "webpackChunkName" comment should add it 1
   },
 
   requireAsync: () => import(
-  /* webpackChunkName: \\"ModA\\" */
+  /* webpackChunkName: \\"baz-ModA\\" */
   './ModA'),
 
   requireSync(props) {

--- a/packages/babel-plugin/src/index.js
+++ b/packages/babel-plugin/src/index.js
@@ -67,7 +67,7 @@ const loadablePlugin = api => {
     return funcPath
   }
 
-  function transformImport(path) {
+  function transformImport(path, state) {
     const callPaths = collectImportCallPaths(path)
 
     // Ignore loadable function that does not have any "import" call
@@ -89,7 +89,7 @@ const loadablePlugin = api => {
 
     const object = t.objectExpression(
       propertyFactories.map(getProperty =>
-        getProperty({ path, callPath, funcPath }),
+        getProperty({ path, callPath, funcPath, state }),
       ),
     )
 
@@ -105,13 +105,13 @@ const loadablePlugin = api => {
   return {
     inherits: syntaxDynamicImport,
     visitor: {
-      CallExpression(path) {
+      CallExpression(path, state) {
         if (!isValidIdentifier(path)) return
-        transformImport(path)
+        transformImport(path, state)
       },
-      'ArrowFunctionExpression|FunctionExpression|ObjectMethod': path => {
+      'ArrowFunctionExpression|FunctionExpression|ObjectMethod': (path, state) => {
         if (!hasLoadableComment(path)) return
-        transformImport(path)
+        transformImport(path, state)
       },
     },
   }

--- a/packages/babel-plugin/src/index.test.js
+++ b/packages/babel-plugin/src/index.test.js
@@ -2,10 +2,13 @@
 import { transform } from '@babel/core'
 import plugin from '.'
 
-const testPlugin = code => {
+const defaultFilename = './baz/fiz.js';
+
+const testPlugin = (code, opts = { filename: defaultFilename }) => {
   const result = transform(code, {
     plugins: [plugin],
     configFile: false,
+    ...opts
   })
 
   return result.code
@@ -36,6 +39,19 @@ describe('plugin', () => {
 
       expect(result).toMatchSnapshot()
     })
+
+    it('should transform to same chunk name when import paths are different', () => {
+      const result1= testPlugin(`
+          loadable(() => import('./foo/bar'))
+        `, { filename: './baz/fiz.js', root: '/homedir/projects/projectRoot' });
+      expect(result1).toMatchSnapshot();
+
+      const result2 = testPlugin(`
+          loadable(() => import('./bar'))
+      `, { filename: './baz/foo/biz.js' , root: '/homedir/projects/projectRoot' });
+
+      expect(result2).toMatchSnapshot();
+    });
 
     describe('with "webpackChunkName" comment', () => {
       it('should use it', () => {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary
Fixes #373. Uses the path relative to the project root when generating chunkNames instead of using the import path directly.

## Test plan
Added a new test in `babel-plugin/src/index.test.js`.
I updated the snapshots and checked the new webpackChunkNames