### PR TITLE
Add required dependencies to run the razzle example

### DIFF
--- a/examples/razzle/package.json
+++ b/examples/razzle/package.json
@@ -7,9 +7,11 @@
     "start:prod": "NODE_ENV=production node build/server.js"
   },
   "dependencies": {
-    "babel-jest": "^24.8.0",
     "@babel/runtime": "^7.1.5",
+    "@loadable/component": "^5.10.2",
+    "@loadable/server": "^5.10.2",
     "@reach/router": "^1.2.1",
+    "babel-jest": "^24.8.0",
     "common-tags": "^1.8.0",
     "express": "^4.16.2",
     "normalize.css": "^8.0.1",


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

The Razzle example is missing @loadable/component and @loadable/server in package.json to run.

## Test plan

With this commit, running the following commands should not fail anymore:
```
cd examples/razzle
npm install
npm run build # or start
```