### PR TITLE
render errorComponent if ctor promise rejected

### DIFF
--- a/packages/component/src/createLoadable.js
+++ b/packages/component/src/createLoadable.js
@@ -194,6 +194,9 @@ function createLoadable({ resolve = identity, render, onLoad }) {
         }
 
         if (error) {
+          if (options.error !== undefined) {
+            return options.error
+          }
           throw error
         }
 

--- a/packages/component/src/loadable.test.js
+++ b/packages/component/src/loadable.test.js
@@ -197,6 +197,15 @@ describe('#loadable', () => {
     load.reject(new Error('boom'))
     await wait(() => expect(container).toHaveTextContent('error'))
   })
+
+  it('render error component when an error occurs and error option specified', async () => {
+    const load = createLoadFunction()
+    const Component = loadable(load, { error: 'errorProp' })
+    const { container } = render(<Component />)
+    expect(container).toBeEmpty()
+    load.reject(new Error('boom'))
+    await wait(() => expect(container).toHaveTextContent('errorProp'))
+  })
 })
 
 describe('#lazy', () => {


### PR DESCRIPTION
Hello. I have a case that I cannot solve with loadable-components.
Case:
If I cannot download some chunk I need to show the popup to user. But popup's background should contain already downloaded part of site. If I try to catch error with React Error Boundaries my js script contains an infinite loop because I rerender React tree with invalid chunk.

My solution allows to fix this edge case. I can put some component with React.Portal via options, for example.