### PR TITLE
Babel plugin: Fixed bug when using + concatenation instead of a template literal

### DIFF
--- a/packages/babel-plugin/src/__snapshots__/index.test.js.snap
+++ b/packages/babel-plugin/src/__snapshots__/index.test.js.snap
@@ -527,6 +527,45 @@ exports[`plugin simple import should work with * in name 1`] = `
 });"
 `;
 
+exports[`plugin simple import should work with + concatenation 1`] = `
+"loadable({
+  chunkName() {
+    return \\"\\";
+  },
+
+  isReady(props) {
+    if (typeof __webpack_modules__ !== 'undefined') {
+      return !!__webpack_modules__[this.resolve(props)];
+    }
+
+    return false;
+  },
+
+  requireAsync: () => import(
+  /* webpackChunkName: \\"\\" */
+  './Mod' + 'A'),
+
+  requireSync(props) {
+    const id = this.resolve(props);
+
+    if (typeof __webpack_require__ !== 'undefined') {
+      return __webpack_require__(id);
+    }
+
+    return eval('module.require')(id);
+  },
+
+  resolve() {
+    if (require.resolveWeak) {
+      return require.resolveWeak('./Mod' + 'A');
+    }
+
+    return eval('require.resolve')('./Mod' + 'A');
+  }
+
+});"
+`;
+
 exports[`plugin simple import should work with template literal 1`] = `
 "loadable({
   chunkName() {

--- a/packages/babel-plugin/src/index.test.js
+++ b/packages/babel-plugin/src/index.test.js
@@ -21,6 +21,14 @@ describe('plugin', () => {
       expect(result).toMatchSnapshot()
     })
 
+    it('should work with + concatenation', () => {
+      const result = testPlugin(`
+        loadable(() => import('./Mod' + 'A'))
+      `)
+
+      expect(result).toMatchSnapshot()
+    })
+
     it('should work with * in name', () => {
       const result = testPlugin(`
         loadable(() => import(\`./foo*\`))

--- a/packages/babel-plugin/src/properties/resolve.js
+++ b/packages/babel-plugin/src/properties/resolve.js
@@ -16,6 +16,12 @@ export default function resolveProperty({ types: t, template }) {
         importArg.node.quasis,
         importArg.node.expressions,
       )
+    } else if (importArg.isBinaryExpression()) {
+      return t.BinaryExpression(
+        importArg.node.operator,
+        importArg.node.left,
+        importArg.node.right,
+      )
     }
     return t.stringLiteral(importArg.node.value)
   }

--- a/packages/babel-plugin/src/properties/resolve.js
+++ b/packages/babel-plugin/src/properties/resolve.js
@@ -16,7 +16,8 @@ export default function resolveProperty({ types: t, template }) {
         importArg.node.quasis,
         importArg.node.expressions,
       )
-    } else if (importArg.isBinaryExpression()) {
+    }
+    if (importArg.isBinaryExpression()) {
       return t.BinaryExpression(
         importArg.node.operator,
         importArg.node.left,


### PR DESCRIPTION
## Summary

Currently, the Babel plugin successfully transpiles template literals, but doesn't work when building a string using `+`. i.e. this works:

```js
import(`my-lib/${componentId}`)
```

But this does not:
```js
import('my-lib/' + componentId)
```

The latter fails with an error:
> TypeError: Property value expected type of string but got null

This PR fixes this issue by checking to see if the import expression is a BinaryExpression. I'm not sure if there are any other types of expressions that should be checked for, but this solves the issue for BinaryExpressions at least.

## Test plan

I added a new test to verify that it works and also tested it in a real app.