### PR TITLE
Improved docs for ssr and code splitting

### DIFF
--- a/website/src/pages/docs/code-splitting.mdx
+++ b/website/src/pages/docs/code-splitting.mdx
@@ -43,6 +43,25 @@ If you’re setting up Webpack yourself, you’ll probably want to read [Webpack
 
 When using Babel, you’ll need to make sure that Babel can parse the dynamic import syntax but is not transforming it. For that you will need [@babel/plugin-syntax-dynamic-import](https://www.npmjs.com/package/@babel/plugin-syntax-dynamic-import).
 
+## Named `import()`
+
+Weckpack's default behaviour, is to name them as `0.js` where 0 is an incremental number depending on how many dynamic
+chunks you are importing in your code.
+
+This will give a very poorly view of which file is loading what code.
+
+To fix that, webpack introduced magic comments, with which a chunck can be named as follows (ie: `math.js`). 
+
+```js
+import(/* webpackChunkName: "math" */ './math').then(math => {
+  console.log(math.add(16, 26))
+})
+```
+
+>NOTE: 
+>When using [Server Side Rendering](/docs/server-side-rendering/), make sure comment and file path are in exacly the same order as above.
+
+
 ## Code Splitting + React
 
 React supports code splitting out of the box with [`React.lazy`](https://reactjs.org/docs/code-splitting.html#reactlazy). However it has [some limitations](/docs/loadable-vs-react-lazy), this is why `@loadable/component` exists.

--- a/website/src/pages/docs/server-side-rendering.mdx
+++ b/website/src/pages/docs/server-side-rendering.mdx
@@ -116,6 +116,18 @@ The `extractor.getScriptTags()` returns a string of multiple `<script>` tags mar
 
 Alternatively the `ChunkExtractor` also has a `getScriptElements()` method that returns an array of React elements.
 
+### Entrypoints
+
+By default, `ChunkExtractor` will collect chunks from the `main` entrypoint (which is the default behaviour of `webpack`), if you would
+like to change this, you can pass an `entrypoints` option like so.
+
+```js
+const extractor = new ChunkExtractor({ 
+  statsFile, 
+  entrypoints: ['client'] // name of the proper webpack endpoint (default: main)
+})
+```
+
 ## Streaming rendering
 
 Loadable is compatible with streaming rendering, if you use it you have to include script when the stream is complete.


### PR DESCRIPTION
Added documentation for 

- Code splitting (named imports, client and server side).
- Server Side Rendering entrypoints.

## Summary

In order to share the knowledge from a problem I've run into recently, I would like to write this points down in the documentation to help people don't make the same mistakes as me.
