### PR TITLE
Accept additional attributes for assets to support SRI

### DIFF
--- a/packages/server/src/ChunkExtractor.js
+++ b/packages/server/src/ChunkExtractor.js
@@ -332,24 +332,6 @@ class ChunkExtractor {
     return smartRequire(mainAsset.path)
   }
 
-  getSriFromFileName(filename) {
-    if (!filename) {
-      return null
-    }
-
-    const asset = this.stats.assets.find(x => x.name === filename)
-    if (!asset) {
-      return null
-    }
-
-    const { integrity } = asset
-    if (!integrity) {
-      return null
-    }
-
-    return { integrity }
-  }
-
   // Main assets
 
   getMainAssets(scriptType) {
@@ -365,10 +347,7 @@ class ChunkExtractor {
     const requiredScriptTag = this.getRequiredChunksScriptTag(extraProps)
     const mainAssets = this.getMainAssets('script')
     const assetsScriptTags = mainAssets.map(asset =>
-      assetToScriptTag({
-        ...asset,
-        ...this.getSriFromFileName(asset.filename),
-      }, extraProps)
+      assetToScriptTag(asset, extraProps)
     )
     return joinTags([requiredScriptTag, ...assetsScriptTags])
   }
@@ -379,10 +358,7 @@ class ChunkExtractor {
     )
     const mainAssets = this.getMainAssets('script')
     const assetsScriptElements = mainAssets.map(asset =>
-      assetToScriptElement({
-        ...asset,
-        ...this.getSriFromFileName(asset.filename),
-      }, extraProps),
+      assetToScriptElement(asset, extraProps),
     )
     return [requiredScriptElement, ...assetsScriptElements]
   }
@@ -398,10 +374,7 @@ class ChunkExtractor {
   getStyleTags(extraProps = {}) {
     const mainAssets = this.getMainAssets('style')
     return joinTags(mainAssets.map(asset =>
-      assetToStyleTag({
-        ...asset,
-        ...this.getSriFromFileName(asset.filename),
-      }, extraProps)
+      assetToStyleTag(asset, extraProps)
     ))
   }
 
@@ -416,10 +389,7 @@ class ChunkExtractor {
   getStyleElements(extraProps = {}) {
     const mainAssets = this.getMainAssets('style')
     return mainAssets.map(asset =>
-      assetToStyleElement({
-        ...asset,
-        ...this.getSriFromFileName(asset.filename),
-      }, extraProps)
+      assetToStyleElement(asset, extraProps)
     )
   }
 

--- a/packages/server/src/ChunkExtractor.js
+++ b/packages/server/src/ChunkExtractor.js
@@ -347,7 +347,7 @@ class ChunkExtractor {
     const requiredScriptTag = this.getRequiredChunksScriptTag(extraProps)
     const mainAssets = this.getMainAssets('script')
     const assetsScriptTags = mainAssets.map(asset =>
-      assetToScriptTag(asset, extraProps)
+      assetToScriptTag(asset, extraProps),
     )
     return joinTags([requiredScriptTag, ...assetsScriptTags])
   }
@@ -373,9 +373,7 @@ class ChunkExtractor {
 
   getStyleTags(extraProps = {}) {
     const mainAssets = this.getMainAssets('style')
-    return joinTags(mainAssets.map(asset =>
-      assetToStyleTag(asset, extraProps)
-    ))
+    return joinTags(mainAssets.map(asset => assetToStyleTag(asset, extraProps)))
   }
 
   getInlineStyleTags(extraProps = {}) {
@@ -388,9 +386,7 @@ class ChunkExtractor {
 
   getStyleElements(extraProps = {}) {
     const mainAssets = this.getMainAssets('style')
-    return mainAssets.map(asset =>
-      assetToStyleElement(asset, extraProps)
-    )
+    return mainAssets.map(asset => assetToStyleElement(asset, extraProps))
   }
 
   getInlineStyleElements(extraProps = {}) {

--- a/packages/webpack-plugin/src/index.js
+++ b/packages/webpack-plugin/src/index.js
@@ -4,19 +4,12 @@ const mkdirp = require('mkdirp')
 
 class LoadablePlugin {
   constructor({
-    additionalAssetAttributes = [],
     filename = 'loadable-stats.json',
     path,
     writeToDisk,
     outputAsset = true,
   } = {}) {
-    this.opts = {
-      additionalAssetAttributes,
-      filename,
-      writeToDisk,
-      outputAsset,
-      path,
-    }
+    this.opts = { filename, writeToDisk, outputAsset, path }
 
     // The Webpack compiler instance
     this.compiler = null
@@ -33,24 +26,6 @@ class LoadablePlugin {
       errorDetails: false,
       timings: false,
     })
-
-    // include extra asset keys if present
-    stats.assets = stats.assets.map((asset) => {
-      const assetAttributes = hookCompiler.assets[asset.name];
-
-      const validAssetAttributes = Object.keys(assetAttributes)
-        .filter(key => this.opts.additionalAssetAttributes.includes(key))
-        .reduce((obj, key) => {
-          obj[key] = assetAttributes[key];
-          return obj;
-        }, {});
-    
-      return ({
-        ...asset,
-        ...validAssetAttributes,
-      })
-    })
-
     const result = JSON.stringify(stats, null, 2)
 
     if (this.opts.outputAsset) {

--- a/packages/webpack-plugin/src/index.js
+++ b/packages/webpack-plugin/src/index.js
@@ -4,12 +4,19 @@ const mkdirp = require('mkdirp')
 
 class LoadablePlugin {
   constructor({
+    additionalAssetAttributes = [],
     filename = 'loadable-stats.json',
     path,
     writeToDisk,
     outputAsset = true,
   } = {}) {
-    this.opts = { filename, writeToDisk, outputAsset, path }
+    this.opts = {
+      additionalAssetAttributes,
+      filename,
+      writeToDisk,
+      outputAsset,
+      path,
+    }
 
     // The Webpack compiler instance
     this.compiler = null
@@ -26,6 +33,24 @@ class LoadablePlugin {
       errorDetails: false,
       timings: false,
     })
+
+    // include extra asset keys if present
+    stats.assets = stats.assets.map((asset) => {
+      const assetAttributes = hookCompiler.assets[asset.name];
+
+      const validAssetAttributes = Object.keys(assetAttributes)
+        .filter(key => this.opts.additionalAssetAttributes.includes(key))
+        .reduce((obj, key) => {
+          obj[key] = assetAttributes[key];
+          return obj;
+        }, {});
+    
+      return ({
+        ...asset,
+        ...validAssetAttributes,
+      })
+    })
+
     const result = JSON.stringify(stats, null, 2)
 
     if (this.opts.outputAsset) {


### PR DESCRIPTION
## Summary
Potential fix for feature request in issue #344 which will add SRI integrity to be html tags before sending to client, if the value exists on the asset.

## Test plan

### Webpack
```js
const SriPlugin = require('webpack-subresource-integrity');
const LoadablePlugin = require('@loadable/webpack-plugin');

module.exports = ({
  ...
  plugins: [
    ...
    new SriPlugin({
      hashFuncNames: ['sha256', 'sha384'],
    }),
    new LoadablePlugin(),
  ],
});
```

### In the server renderer script
Also worth adding the `crossorigin` key (this functionality already existed and isn't being introduced by this PR)
```js
chunkExtractor.getScriptTags({ crossorigin: 'anonymous' })
```

### Start application
Confirm that during SSR run the tags have `integrity` key with correct value
```html
<script
    async
    data-chunk="HelloWorld"
    src="/1.bundle.js"
    crossorigin="anonymous"
    integrity="sha256-mYmvbcbExknkCdg+X/j/8zsdpRcm29eJ3lpF4wfnl+4= sha384-gECBjN17ng81O/ueB9Dz8Vor95n36djp9M/oWAXg7+4qgCPArWkzSqlEchJlQK3j"
></script>
```