### PR TITLE
[doc] use webpackPreload hint in example

### DIFF
--- a/website/src/pages/docs/prefetching.mdx
+++ b/website/src/pages/docs/prefetching.mdx
@@ -42,10 +42,6 @@ function App() {
     </div>
   )
 }
-
-const OtherComponent = loadable(() =>
-  import(/* webpackPreload: true */ './OtherComponent'),
-)
 ```
 
 > `preload` is not available server-side, you should only call it client-side. If you want to use prefetching server-side, use webpack hints instead.

--- a/website/src/pages/docs/prefetching.mdx
+++ b/website/src/pages/docs/prefetching.mdx
@@ -44,7 +44,7 @@ function App() {
 }
 
 const OtherComponent = loadable(() =>
-  import(/* webpackPrefetch: true */ './OtherComponent'),
+  import(/* webpackPreload: true */ './OtherComponent'),
 )
 ```
 


### PR DESCRIPTION
## Summary

Small update to the example in the documentation listing `webpackPrefetch` when `webpackPreload` is intended as far as I can tell.

## Test plan

N/A