### PR TITLE
feat: passing chunkName and extractor to Component

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dist/
 lib/
 /coverage/
 examples/*/yarn.lock
+.idea

--- a/packages/component/.size-snapshot.json
+++ b/packages/component/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "dist/loadable.cjs.js": {
-    "bundled": 12683,
-    "minified": 6125,
-    "gzipped": 2203
+    "bundled": 12941,
+    "minified": 6233,
+    "gzipped": 2237
   },
   "dist/loadable.esm.js": {
-    "bundled": 12300,
-    "minified": 5816,
-    "gzipped": 2135,
+    "bundled": 12558,
+    "minified": 5924,
+    "gzipped": 2166,
     "treeshaked": {
       "rollup": {
         "code": 259,
         "import_statements": 259
       },
       "webpack": {
-        "code": 5068
+        "code": 5176
       }
     }
   }

--- a/packages/component/.size-snapshot.json
+++ b/packages/component/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "dist/loadable.cjs.js": {
-    "bundled": 12941,
-    "minified": 6233,
-    "gzipped": 2237
+    "bundled": 12935,
+    "minified": 6216,
+    "gzipped": 2234
   },
   "dist/loadable.esm.js": {
-    "bundled": 12558,
-    "minified": 5924,
-    "gzipped": 2166,
+    "bundled": 12552,
+    "minified": 5907,
+    "gzipped": 2163,
     "treeshaked": {
       "rollup": {
         "code": 259,
         "import_statements": 259
       },
       "webpack": {
-        "code": 5176
+        "code": 5159
       }
     }
   }

--- a/packages/component/src/createLoadable.js
+++ b/packages/component/src/createLoadable.js
@@ -180,6 +180,12 @@ function createLoadable({ resolve = identity, render, onLoad }) {
           ...props
         } = this.props
         const { error, loading, result } = this.state
+        const loadableProps = {};
+
+        if (props.__chunkExtractor) {
+          loadableProps.loadableChunkName = ctor.chunkName(this.props);
+          loadableProps.loadableChunkExtractor = __chunkExtractor;
+        }
 
         if (options.suspense) {
           const cachedResult = this.getCache()
@@ -189,7 +195,11 @@ function createLoadable({ resolve = identity, render, onLoad }) {
             fallback: null,
             result: cachedResult,
             options,
-            props: { ...props, ref: forwardedRef },
+            props: {
+              ...loadableProps,
+              ...props,
+              ref: forwardedRef,
+            },
           })
         }
 
@@ -208,7 +218,11 @@ function createLoadable({ resolve = identity, render, onLoad }) {
           fallback,
           result,
           options,
-          props: { ...props, ref: forwardedRef },
+          props: {
+            ...loadableProps,
+            ...props,
+            ref: forwardedRef,
+          },
         })
       }
     }

--- a/packages/component/src/createLoadable.js
+++ b/packages/component/src/createLoadable.js
@@ -182,7 +182,7 @@ function createLoadable({ resolve = identity, render, onLoad }) {
         const { error, loading, result } = this.state
         const loadableProps = {};
 
-        if (props.__chunkExtractor) {
+        if (__chunkExtractor) {
           loadableProps.loadableChunkName = ctor.chunkName(this.props);
           loadableProps.loadableChunkExtractor = __chunkExtractor;
         }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
I want to get dynamic css chunks before `renderToNodeStream` when SSR.

This PR add 2 parameters(`extractor` and `chunkName`) to the child component wrapped by `loadable`.

## Test plan
```js
// test.js
export default function Test(props) {
    // return 'Test & Assets'
    return `${props.loadableChunkName} & ${props.loadableChunkExtractor.getChunkAssets([props.loadableChunkName])}`;
}

loadable(() => import('./test'))
```
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
